### PR TITLE
Docs: Document timestampMs transaction semantics

### DIFF
--- a/api-types/transaction-types.md
+++ b/api-types/transaction-types.md
@@ -13,6 +13,7 @@ Although each transaction type has its own structure and required properties, al
 - `blockId` — Block ID that includes the transaction and was forged
 - `type` — Transaction type
 - `timestamp` — Transaction time specified by the sender, measured in seconds since the epoch (Sep 02, 2017, 17:00:00 GMT+0000)
+- `timestampMs` — Optional transaction time specified by the sender, measured in milliseconds since the ADAMANT epoch. After the `spaceship` consensus activation, upgraded nodes can store and return this field for transactions that include it. It is not included in transaction signatures or IDs. When present, it belongs to the same ADAMANT second as `timestamp`; clients should create `timestamp` with `Math.floor(timestampMs / 1000)`, prefer `timestampMs` for ordering, and fall back to `timestamp * 1000` when it is missing.
 - `block_timestamp` — Transaction's block timestamp. It's up to the client how to interpret this field. It's recommended to consider both `timestamp` and `block_timestamp` when determining the transaction timestamp
 - `senderPublicKey` — Sender's public key in hex
 - `senderId` — Sender's ADAMANT address

--- a/api/making-requests.md
+++ b/api/making-requests.md
@@ -67,7 +67,9 @@ Examples:
     "nodeTimestamp": 239258018,
     "error": "Object didn't pass validation for format address: U"
   }
-  ```
+```
+
+The `/api/node/status` endpoint also returns `nodeTimestampMs` and `unixTimestampMs` as node clock metadata. They do not affect consensus.
 
 ## OpenAPI Schema
 

--- a/api/transactions-query-language.md
+++ b/api/transactions-query-language.md
@@ -243,6 +243,8 @@ Offset value for results, integer. Default is `0`.
 
 Ordering request results by field name.
 
+When ordering by `timestamp`, upgraded nodes prefer `timestampMs` when it is available and fall back to `timestamp * 1000`. This affects transaction, chat, chatroom, and KVS/state listing endpoints that expose timestamp ordering. `timestampMs` is available only for transactions that include it and, for consensus-stored blockchain data, after the `spaceship` activation.
+
 - **Example**
 
   `https://endless.adamant.im/api/transactions?orderBy=timestamp:desc`

--- a/api/websocket.md
+++ b/api/websocket.md
@@ -41,6 +41,8 @@ Example response:
 {
   "success": true,
   "nodeTimestamp": 226901657,
+  "nodeTimestampMs": 226901657123,
+  "unixTimestampMs": 1731273257123,
   // ...
   "wsClient": {
     "enabled": true,
@@ -52,6 +54,8 @@ Example response:
 ## Listening to transactions
 
 ADAMANT nodes send transactions over WebSocket. This includes both confirmed and unconfirmed transactions.
+
+After the `spaceship` consensus activation, transaction payloads can include `timestampMs` when the transaction was created with millisecond precision and the node stored it. This value is measured in milliseconds since the ADAMANT epoch. Clients should prefer it for message ordering and fall back to `timestamp * 1000` when it is missing or `null`.
 
 ### Understanding unconfirmed transactions
 

--- a/core-concepts.md
+++ b/core-concepts.md
@@ -31,6 +31,23 @@ const getEpochTime = (time: number = Date.now()) =>
   Math.floor((time - EPOCH) / 1000);
 ```
 
+Some upgraded transaction responses also include **`timestampMs`**. This value uses the same ADAMANT epoch, but in milliseconds. It is not a Unix timestamp.
+
+```ts
+/**
+ * Converts provided timestamp into ADAMANT's epoch timestamp in ms
+ * @param time - timestamp in Unix ms
+ */
+const getEpochTimeMs = (time: number = Date.now()) => time - EPOCH;
+
+const timestampMs = getEpochTimeMs();
+const timestamp = Math.floor(timestampMs / 1000);
+```
+
+Clients should derive `timestamp` from `timestampMs` with `Math.floor(timestampMs / 1000)`. Do not use `Math.round()` or `Math.ceil()`, because this can make `timestampMs` belong to the previous ADAMANT second while `timestamp` points to the next one.
+
+After the `spaceship` consensus activation, nodes can store and return `timestampMs` for transactions that include it. Historical transactions and transactions from older clients may still have `timestampMs: null`, so clients should prefer `timestampMs` for ordering when it exists and fall back to `timestamp * 1000` otherwise.
+
 You can get blockchain's epoch time using [`/blocks/getEpochTime`](/api-endpoints/blockchain.md#get-blockchain-epoch) endpoint. Additionally, consider using [`/blocks/getStatus`](/api-endpoints/blockchain.md#get-adamant-blockchain-network-info) or [`/node/status`](/api-endpoints/blockchain.md#get-blockchain-and-network-status) endpoints to get more blockchain and network information in a single request.
 
 ## Milestones


### PR DESCRIPTION
## Description

Updates the public documentation for `timestampMs` transaction semantics.

This PR clarifies that `timestampMs` is ADAMANT epoch milliseconds, not Unix milliseconds; clients should derive `timestamp` using `Math.floor(timestampMs / 1000)`; transaction ordering should prefer `timestampMs` and fall back to `timestamp * 1000`; and stored blockchain `timestampMs` data is available after the `spaceship` consensus activation when transactions include it.

It also documents `nodeTimestampMs` and `unixTimestampMs` returned by `/api/node/status` as node clock metadata, not consensus data.

## Related

- Adamant-im/adamant#209
- Adamant-im/adamant#210
- Adamant-im/AIPs#62

## How to test

```bash
npm run docs:build
git diff --check
```

Result: passed.