### PR TITLE
Docs: Update documentation for ADAMANT Node v0.10.0

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
           { text: 'Installation', link: '/own-node/installation' },
           { text: 'Configuration', link: '/own-node/configuration' },
           { text: 'Testnet', link: '/own-node/testnet' },
+          { text: 'Localnet', link: '/own-node/localnet' },
           { text: 'Consensus', link: '/own-node/consensus' },
           { text: 'Syncing', link: '/own-node/syncing' },
         ],
@@ -110,11 +111,28 @@ export default defineConfig({
           { text: 'Java', link: '/examples/java' },
         ],
       },
+      {
+        text: 'SDK',
+        items: [
+          {
+            text: 'JavaScript API Client',
+            link: 'https://github.com/Adamant-im/adamant-api-jsclient',
+          },
+          {
+            text: 'Console Tool',
+            link: 'https://github.com/Adamant-im/adamant-console',
+          },
+          {
+            text: 'API Schema',
+            link: 'https://github.com/Adamant-im/adamant-schema',
+          },
+        ],
+      },
     ],
     nav: [
       {
         text: 'API Schema',
-        link: 'https://github.com/adamant-im/adamant-schema',
+        link: 'https://schema.adamant.im/',
       },
     ],
     socialLinks: [

--- a/.vitepress/theme/SidebarVersion.vue
+++ b/.vitepress/theme/SidebarVersion.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { version } from '../../package.json';
+</script>
+
+<template>
+  <a
+    class="nav-version"
+    href="https://github.com/Adamant-im/adamant/releases"
+    target="_blank"
+    rel="noopener noreferrer"
+  >v{{ version }}</a>
+</template>
+
+<style scoped>
+.nav-version {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vp-c-text-3);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 1px 8px;
+  line-height: 20px;
+  text-decoration: none;
+  vertical-align: middle;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.nav-version:hover {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@
 import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
+import SidebarVersion from './SidebarVersion.vue'
 import './style.css'
 
 export default {
@@ -9,6 +10,7 @@ export default {
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
+      'nav-bar-title-after': () => h(SidebarVersion),
     })
   },
   enhanceApp({ app, router, siteData }) {

--- a/README.md
+++ b/README.md
@@ -21,4 +21,8 @@ This starts a hot-reload server so you can preview the site and take advantage o
 
 ## Links
 
-- [Swagger Schema](https://schema.adamant.im/)
+- [ADAMANT Website](https://adamant.im)
+- [ADAMANT Node repository](https://github.com/Adamant-im/adamant)
+- [ADAMANT Improvement Proposals (AIPs)](https://aips.adamant.im)
+- [API Schema (Swagger)](https://schema.adamant.im/)
+- [API Schema source](https://github.com/Adamant-im/adamant-schema)

--- a/core-concepts.md
+++ b/core-concepts.md
@@ -4,7 +4,7 @@ Basic concepts of the ADAMANT blockchain you need to know if you're interacting 
 
 ## Native Token
 
-**ADM** is the native token of the ADAMANT blockchain. It’s used to pay transaction fees and can be transferred between accounts. For consistency and precision, ADM amounts and **fees** are stored as strings in transactions and measured in 1/10<sup>8</sup> ADM (1 ADM = 100,000,000).
+**ADM** is the native token of the ADAMANT blockchain. It's used to pay transaction fees and can be transferred between accounts. For consistency and precision, ADM amounts and **fees** are stored as strings in transactions and measured in 1/10<sup>8</sup> ADM (1 ADM = 100,000,000).
 
 ## Transaction Fees
 
@@ -46,15 +46,33 @@ const timestamp = Math.floor(timestampMs / 1000);
 
 Clients should derive `timestamp` from `timestampMs` with `Math.floor(timestampMs / 1000)`. Do not use `Math.round()` or `Math.ceil()`, because this can make `timestampMs` belong to the previous ADAMANT second while `timestamp` points to the next one.
 
-After the `spaceship` consensus activation, nodes can store and return `timestampMs` for transactions that include it. Historical transactions and transactions from older clients may still have `timestampMs: null`, so clients should prefer `timestampMs` for ordering when it exists and fall back to `timestamp * 1000` otherwise.
+After the [`spaceship`](/own-node/consensus.md#spaceship) consensus activation, nodes can store and return `timestampMs` for transactions that include it. Historical transactions and transactions from older clients may still have `timestampMs: null`, so clients should prefer `timestampMs` for ordering when it exists and fall back to `timestamp * 1000` otherwise.
 
-You can get blockchain's epoch time using [`/blocks/getEpochTime`](/api-endpoints/blockchain.md#get-blockchain-epoch) endpoint. Additionally, consider using [`/blocks/getStatus`](/api-endpoints/blockchain.md#get-adamant-blockchain-network-info) or [`/node/status`](/api-endpoints/blockchain.md#get-blockchain-and-network-status) endpoints to get more blockchain and network information in a single request.
+You can get the blockchain epoch time using the [`/blocks/getEpochTime`](/api-endpoints/blockchain.md#get-blockchain-epoch) endpoint. Additionally, consider using [`/blocks/getStatus`](/api-endpoints/blockchain.md#get-adamant-blockchain-network-info) or [`/node/status`](/api-endpoints/blockchain.md#get-blockchain-and-network-status) endpoints to get more blockchain and network information in a single request.
+
+## Blocks and Rounds
+
+The ADAMANT blockchain is organized into **blocks**. Each block is produced by a delegate and contains a set of confirmed transactions.
+
+A **round** consists of exactly **101 blocks** — one block slot per active delegate. At the end of each round, the set of active delegates may change based on updated vote weights. Forging order within a round is deterministic and shuffled from the active delegate list.
+
+Each block slot has a fixed duration of **5 seconds**. If a delegate misses their slot (e.g., due to downtime), that slot is skipped and the next delegate's slot begins on schedule.
+
+## Delegates and Voting
+
+ADAMANT uses **Delegated Proof of Stake (DPoS)**. There are exactly **101 active delegates** at any given time. They are selected by token-holder votes and take turns forging blocks in each round.
+
+Any ADAMANT account can register as a delegate and receive votes. Token holders can vote for up to **33 delegates** at once. Each vote is weighted by the voter's ADM balance.
+
+After the [`fairSystem`](/own-node/consensus.md#fairsystem) consensus upgrade, vote weight is also adjusted by each delegate's **productivity** (the fraction of block slots they successfully forged). This discourages inactive delegates from maintaining their position purely through accumulated votes.
+
+Delegates earn ADM rewards for each block they forge. You can query delegate information using the [Delegates API](/api-endpoints/delegates.md).
 
 ## Milestones
 
 Milestones define block rewards for delegates and are triggered at specific block heights.
 
-You can use REST API to:
+You can use the REST API to:
 
 - [Get blockchain reward](/api-endpoints/blockchain.md#get-blockchain-reward)
 - [Get current milestone number](/api-endpoints/blockchain.md#get-blockchain-milestone)

--- a/index.md
+++ b/index.md
@@ -2,21 +2,21 @@
 
 ADAMANT is a **decentralized** messenger powered by a Delegated Proof of Stake (DPoS) blockchain. Anyone can run a node and interact with the network via REST and WebSocket APIs.
 
-You don’t have to run your own node to use the ADAMANT Messenger. It’s safe to use public nodes — all messages and transactions are **encrypted and signed locally** before being sent.
+You don't have to run your own node to use ADAMANT Messenger, run apps and integrations. It's safe to use public nodes — all messages and transactions are **encrypted and signed locally** before being sent.
 
 ## Join the Decentralization
 
-### Run own node
+### Run your own node
 
 While you can connect to any ADAMANT node with an enabled API, it is recommended to [run your own node](https://news.adamant.im/how-to-run-your-adamant-node-on-ubuntu-990e391e8fcc) for the following reasons:
 
-- **Support decentralization** – More nodes means stronger network
-- **Robust performance** – Requests are processed faster through your own node.
-- **High reliability** – You maintain full control over the API’s availability
+- **Support decentralization** – More nodes means a stronger network
+- **Robust performance** – Requests are processed faster through your own node
+- **High reliability** – You maintain full control over the API's availability
 
 To get started, check out the [Installation](/own-node/installation.md) and [Configuration](/own-node/configuration.md) guides — they cover everything you need to install, sync, and run a node.
 
-You can also run a [Testnet node](/own-node/testnet.md) to experiment and try out different things in a safe environment.
+You can also run a [Testnet node](/own-node/testnet.md) to experiment in a safe environment, or a [Localnet](/own-node/localnet.md) to run multiple nodes on one machine for isolated testing.
 
 ::: tip
 If you're building a service with a near-100% uptime requirement, implement a health check in your application — similar to [adamant-api-jsclient](https://github.com/Adamant-im/adamant-api-jsclient/blob/07016c89b57863ac379ebfcbf6cf464a0639d3b1/src/api/index.ts#L183) or [the ADAMANT PWA](https://github.com/Adamant-im/adamant-im/blob/f5c7b7ce95fb5df3785a3458abc4e0b132c18791/src/lib/nodes/abstract.client.ts). While connecting to public nodes is possible, running three or more separate ADAMANT nodes is significantly more reliable.
@@ -38,19 +38,19 @@ https://sunshine.adamant.im
 https://tauri.adm.im
 ```
 
-However, **we still recommend running your own node** for reliability and performance and to help support decentralized messaging.
+However, **we still recommend running your own node** for reliability and performance, and to help support decentralized messaging.
 
-## Interacting with the nodes
+## Interacting with the Nodes
 
 If you're building a tool or app on the ADAMANT blockchain, you can use the REST API to interact with the network.
 
-For real-time applications — such as messengers, or bots — the WebSocket API provides instant updates and optimal performance.
+For real-time applications — such as messengers or bots — the WebSocket API provides instant updates and optimal performance.
 
 ### Choosing a node
 
 You can connect to **any public node** in the ADAMANT network.
 
-To ensure you're on the correct network, check the node’s `nethash`. For the **mainnet**, the `nethash` is:
+To ensure you're on the correct network, check the node's `nethash`. For the **mainnet**, the `nethash` is:
 
 ```
 bd330166898377fb28743ceef5e43a5d9d0a3efd9b3451fb7bc53530bb0a6d64
@@ -66,10 +66,10 @@ https://endless.adamant.im/api/blocks/getNethash
 
 This list includes some libraries and frameworks to interact with ADAMANT nodes **developed by the ADAMANT community**.
 
-- **adamant-api-jsclient**. JavaScript framework to interact with ADAMANT REST and WebSocket API with reliability in mind.
+- **adamant-api-jsclient**. JavaScript framework to interact with the ADAMANT REST and WebSocket API with reliability in mind.
 
   https://github.com/adamant-im/adamant-api-jsclient
 
-- **adamant-console**. Command-line interface and JSON RPC server to make requests to ADAMANT network.
+- **adamant-console**. Command-line interface and JSON RPC server for making requests to the ADAMANT network.
 
   https://github.com/adamant-im/adamant-console

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 ADAMANT is a **decentralized** messenger powered by a Delegated Proof of Stake (DPoS) blockchain. Anyone can run a node and interact with the network via REST and WebSocket APIs.
 
-You don't have to run your own node to use ADAMANT Messenger, run apps and integrations. It's safe to use public nodes — all messages and transactions are **encrypted and signed locally** before being sent.
+You don't have to run your own node to use ADAMANT Messenger or run apps and integrations. It's safe to use public nodes — all messages and transactions are **encrypted and signed locally** before being sent.
 
 ## Join the Decentralization
 

--- a/own-node/configuration.md
+++ b/own-node/configuration.md
@@ -24,41 +24,135 @@ You can copy the configuration files from the default templates.
 
   You can learn more about testnet on the [Testnet page](./testnet.md).
 
+## Configuration Overrides
+
+You can override specific configuration values at startup without editing `config.json` or `test/config.json` directly. Overrides are applied in this order: selected config file → each `--config-overrides` file in command-line order → repeated `--config-set` values → legacy CLI shortcuts (`--port`, `--address`, `--peers`, `--log`, `--snapshot`). The final resolved config is validated against the node config schema before startup.
+
+Use `--config-set` for individual dot-path values:
+
+```sh
+node app.js \
+  --config test/config.json \
+  --genesis test/genesisBlock.json \
+  --config-set consensusActivationHeights.fairSystem=4359465 \
+  --config-set 'redis={ "url": "redis://127.0.0.1:6379/1", "password": null }'
+```
+
+The same flags work through npm scripts:
+
+```sh
+npm run start -- --config-set port=36667
+npm run start:testnet -- --config-set api.access.public=true
+```
+
+Use `--config-overrides` for a file with multiple overrides. Non-`.json` files are parsed as env-style `key=value` pairs (one per line):
+
+```dotenv
+consensusActivationHeights.fairSystem=4359465
+redis={ "url": "redis://127.0.0.1:6379/1", "password": null }
+```
+
+Files ending in `.json` are parsed as nested JSON partial overrides:
+
+```json
+{
+  "consensusActivationHeights": {
+    "fairSystem": 4359465
+  },
+  "redis": {
+    "url": "redis://127.0.0.1:6379/1",
+    "password": null
+  }
+}
+```
+
+Values are parsed as JSON first, so numbers, booleans, `null`, arrays, and objects keep their types. Unknown paths, malformed values, and schema-invalid values fail before startup.
+
+::: warning
+Be careful when overriding `consensusActivationHeights.*`: using activation heights that do not match the selected network can make a node diverge from that network. See [Consensus](./consensus.md) for details on consensus activation.
+:::
+
 ## Logging
 
-- **Log file path**
+The node has three configurable log outputs: a general log, a debug log, and console output.
 
-  Specify path to the log file using `logFileName` property:
+- **General Log**
 
-  ```json
-  {
-    "logFileName": "path/to/your/log/file.txt"
-  }
-  ```
-
-  You can use `.log`, `.txt` or any other extension.
-
-- **Logging Level**
-
-  The logging level can differ between the file and the console for debugging purposes:
+  Configures the main log file with `generalLog`:
 
   ```json
   {
-    "fileLogLevel": "warn",
-    "consoleLogLevel": "debug"
+    "generalLog": {
+      "enabled": true,
+      "fileName": "logs-mainnet/adamant.log",
+      "level": "warn",
+      "rotate": {
+        "enabled": true,
+        "maxSize": "300M",
+        "retain": 5,
+        "rotateInterval": "0 0 0 1 *",
+        "rotateOnRestart": true
+      }
+    }
   }
   ```
 
-  Possible log levels:
+  - `enabled`: Enable or disable this log output.
+  - `fileName`: Path to the log file. You can use `.log`, `.txt`, or any other extension.
+  - `level`: Minimum log level to write.
+  - `rotate.enabled`: Enable log rotation.
+  - `rotate.maxSize`: Maximum log file size before rotation (e.g., `"300M"`).
+  - `rotate.retain`: Number of rotated files to keep.
+  - `rotate.rotateInterval`: Cron expression for scheduled rotation.
+  - `rotate.rotateOnRestart`: Rotate the log file on every node restart.
 
-  - `trace`
-  - `debug`
-  - `log`
-  - `info`
-  - `warn`
-  - `error`
-  - `fatal`
-  - `none`
+- **Debug Log**
+
+  Configures a verbose debug log file with `debugLog`. Accepts the same properties as `generalLog`. Typically set to `level: "trace"` to capture all output.
+
+  ```json
+  {
+    "debugLog": {
+      "enabled": true,
+      "fileName": "logs-mainnet/adamant_debug.log",
+      "level": "trace",
+      "rotate": {
+        "enabled": true,
+        "maxSize": "300M",
+        "retain": 7,
+        "rotateInterval": "0 0 * * *",
+        "rotateOnRestart": true
+      }
+    }
+  }
+  ```
+
+- **Console Log**
+
+  Configures logging to standard output with `consoleLog`:
+
+  ```json
+  {
+    "consoleLog": {
+      "enabled": true,
+      "level": "info"
+    }
+  }
+  ```
+
+  - `enabled`: Enable or disable console output.
+  - `level`: Minimum log level to print.
+
+Possible log levels (from least to most verbose):
+
+- `fatal`
+- `error`
+- `warn`
+- `info`
+- `log`
+- `debug`
+- `trace`
+- `none` — disables all output for that target
 
 ## Server Configuration
 
@@ -93,6 +187,30 @@ You can copy the configuration files from the default templates.
     "trustProxy": false
   }
   ```
+
+- **Cache**
+
+  Enable the in-memory Redis cache for API responses with `cacheEnabled`:
+
+  ```json
+  {
+    "cacheEnabled": false
+  }
+  ```
+
+  Cache is disabled by default on mainnet and enabled on testnet. Enabling it can improve API response times for high-traffic public nodes.
+
+- **Top Accounts**
+
+  Enable the `/api/accounts/top` endpoint (returns accounts sorted by balance) with `topAccounts`:
+
+  ```json
+  {
+    "topAccounts": false
+  }
+  ```
+
+  This endpoint is disabled by default on mainnet. Enabling it on a high-traffic node may have a performance impact.
 
 ## Database Configuration
 
@@ -149,7 +267,7 @@ Redis is used for caching. Required.
 ## API Configuration
 
 > [!Note]
-> Even when a node's Public API is disabled (including `api.enabled` = `false`, `api.access.public` = `false`), other nodes can still connect to it for block exchange—such nodes still participate in blockchain synchronization.
+> Even when a node's Public API is disabled (including `api.enabled` = `false`, `api.access.public` = `false`), other nodes can still connect to it for block exchange — such nodes still participate in blockchain synchronization.
 
 > [!Warning]
 > Nodes with a Public API, used by applications, require more CPU since they execute many SQL queries.
@@ -198,7 +316,7 @@ Redis is used for caching. Required.
     "peers": {
       "enabled": true,
       "list": [
-        { "ip": "5.161.68.61", "port": 36666 },
+        { "ip": "95.216.114.252", "port": 36666 },
         { "ip": "149.102.157.15", "port": 36666 }
       ],
       "access": { "blackList": [] },
@@ -216,7 +334,7 @@ Redis is used for caching. Required.
   ```
 
   - `enabled`: Enable or disable peer connections (default: `true`).
-  - `list`: List of peer IPs and ports.
+  - `list`: List of peer IPs and ports. See the full list in [config.default.json](https://github.com/Adamant-im/adamant/blob/master/config.default.json).
   - `access.blackList`: List of blocked IPs (e.g., `["222.222.222.222"]`).
   - `options.limits`: Peer rate-limiting options:
     - `max`: Max requests per window (e.g., `0`, unlimited).
@@ -249,13 +367,13 @@ Redis is used for caching. Required.
 
     - Example: If `parallelLimit = 5` and `broadcastLimit = 10`, the node will first send transactions to 5 peers asynchronously, then process another 5.
 
-  - `releaseLimit`: The number of transactions, blocks and signatures included in each broadcast (recommended: `25`).
+  - `releaseLimit`: The number of transactions, blocks, and signatures included in each broadcast (recommended: `25`).
 
-    - Example: If 10 transactions are waiting to be broadcasted and `releaseLimit = 5`, only 5 will be sent in the next broadcast
+    - Example: If 10 transactions are waiting to be broadcast and `releaseLimit = 5`, only 5 will be sent in the next broadcast.
 
   - `relayLimit`: The maximum relay count at which a node will still broadcast an unconfirmed transaction (recommended: `4`).
 
-    - Example: If a transaction has already been broadcasted to 5 nodes and `relayLimit = 4`, the node will process the transaction but won't broadcast it further.
+    - Example: If a transaction has already been broadcast to 5 nodes and `relayLimit = 4`, the node will process the transaction but will not broadcast it further.
 
 ## Transaction Configuration
 
@@ -272,6 +390,24 @@ Redis is used for caching. Required.
   ```
 
   - `maxTxsPerQueue`: Max transactions per queue (recommended: `1000`).
+
+## Consensus Activation Heights
+
+The `consensusActivationHeights` object defines the block heights at which consensus upgrades become active:
+
+```json
+{
+  "consensusActivationHeights": {
+    "fairSystem": 4359465,
+    "spaceship": 100000000
+  }
+}
+```
+
+- `fairSystem`: Height at which the Fair dPoS voting system activates. On mainnet, this is `4359465`. See [Consensus](./consensus.md#fairsystem) for details.
+- `spaceship`: Height at which the `timestampMs` field is preserved in transactions. On mainnet, this is `100000000` (far future; already activated on testnet). See [Consensus](./consensus.md#spaceship) for details.
+
+These values match the mainnet network. **Do not change them for a mainnet node**, as mismatched heights will cause the node to diverge from the network. For testnet or localnet experimentation, you can override these values using [configuration overrides](#configuration-overrides).
 
 ## Forging Configuration
 
@@ -292,7 +428,7 @@ Redis is used for caching. Required.
   ```
 
   - `force`: Force forging regardless of network state (default: `false`).
-  - `secret`: List of forging pass phrases.
+  - `secret`: List of forging passphrases.
   - `access.whiteList`: Allowed forging IPs (e.g., `["127.0.0.1"]`).
 
 ## Loading Configuration
@@ -354,7 +490,7 @@ Redis is used for caching. Required.
   ```
 
   - `masterrequired`: Require master password for DApp execution (recommended: `true`).
-  - `masterpassword`: Master password (e.g., `"<empty>"`).
+  - `masterpassword`: Master password (e.g., `""`).
   - `autoexec`: List of auto-executable scripts (e.g., `[]`).
 
 ## WebSocket Client Configuration
@@ -373,7 +509,7 @@ Redis is used for caching. Required.
   ```
 
   - `enabled`: Enable or disable WebSocket client (e.g., `true`).
-  - `portWS`: WebSocket client port (e.g., `36668`).
+  - `portWS`: WebSocket client port (e.g., `36668` for mainnet, `36665` for testnet).
 
 ## WebSocket Node Configuration
 
@@ -393,7 +529,7 @@ Redis is used for caching. Required.
 
   - `enabled`: Enable or disable WebSocket node-to-node communication.
   - `maxBroadcastConnections`: Maximum number of outbound WebSocket connections used to broadcast data to other nodes.
-  - `maxReceiveConnections`: Maximum number of inbound WebSocket connections to other nodes.
+  - `maxReceiveConnections`: Maximum number of inbound WebSocket connections from other nodes.
 
 ## Nethash Configuration
 
@@ -417,19 +553,19 @@ Redis is used for caching. Required.
   }
   ```
 
-  You can find or generate a `nethash` using the genesis block (`genesisBlock.json` or `test/genesisBlock.json` based on your blockchain network).
+  You can find or verify the `nethash` using the genesis block (`genesisBlock.json` or `test/genesisBlock.json` based on your blockchain network). The node derives `nethash` from `genesisBlock.payloadHash` — the SHA-256 payload hash verified from the genesis block transactions. It is not a random identifier.
 
 ## CORS
 
-- **Cors**
+- **CORS**
 
-  By default, ADAMANT Node allows any origins to make requests. You can control [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) with the `cors` object option in `config.json` that accepts following properties:
+  By default, ADAMANT Node allows any origin to make requests. You can control [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) with the `cors` object in `config.json`, which accepts the following properties:
 
   - `origin`: Configures the **Access-Control-Allow-Origin** CORS header. Possible values:
-    - `Boolean` - set `origin` to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined by `req.header('Origin')`, or set it to `false` to disable CORS.
-    - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
-    - `Array` - set `origin` to an array of valid origins. For example `["http://example1.com", "http://example2.com/"]` will accept any request from "http://example1.com" or "example2.com".
-  - `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).
+    - `Boolean` — set `origin` to `true` to reflect the request origin, or set it to `false` to disable CORS.
+    - `String` — set `origin` to a specific origin. For example, `"http://example.com"` allows only requests from that origin.
+    - `Array` — set `origin` to an array of valid origins. For example `["http://example1.com", "http://example2.com/"]`.
+  - `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (e.g., `'GET,PUT,POST'`) or an array (e.g., `['GET', 'PUT', 'POST']`).
 
   Example:
 

--- a/own-node/consensus.md
+++ b/own-node/consensus.md
@@ -79,8 +79,8 @@ This is useful when running a [Localnet](./localnet.md) to test consensus behavi
 
   ```json
   {
-    "timestamp": 1716829200,
-    "timestampMs": 1716829200456,
+    "timestamp": 212457600,
+    "timestampMs": 212457600456,
     "signature": "..."
   }
   ```

--- a/own-node/consensus.md
+++ b/own-node/consensus.md
@@ -2,30 +2,91 @@
 
 Consensus is the process that makes sure all nodes in the network agree on the state of the blockchain. It controls how transactions are confirmed and how new blocks are added, keeping the network consistent and secure.
 
-This page describes changes to the consensus rules.
+ADAMANT uses a **Delegated Proof of Stake (DPoS)** consensus mechanism, where a fixed set of 101 active delegates take turns forging blocks in a deterministic round-robin order. The active delegate set is selected by token-holder votes and refreshed every round (101 blocks).
 
-## Spaceship
+This page describes changes to the consensus rules and how they activate.
 
-- **Target block for activation:** `100,000,000`
+## Consensus Activation Heights
+
+Consensus upgrades are not applied retroactively. Instead, each upgrade activates at a specific block height defined in the node's `consensusActivationHeights` configuration:
+
+```json
+{
+  "consensusActivationHeights": {
+    "fairSystem": 4359465,
+    "spaceship": 100000000
+  }
+}
+```
+
+Nodes that diverge from these activation heights will fork from the network. **Do not change these values on a mainnet node.**
+
+For testnet or localnet testing, you can override activation heights using [configuration overrides](./configuration.md#configuration-overrides):
+
+```sh
+node app.js \
+  --config test/config.json \
+  --genesis test/genesisBlock.json \
+  --config-set consensusActivationHeights.fairSystem=203 \
+  --config-set consensusActivationHeights.spaceship=405
+```
+
+This is useful when running a [Localnet](./localnet.md) to test consensus behavior in an isolated environment.
+
+## fairSystem
+
+- **Activation height:** `4,359,465` (mainnet)
 
 - **Description**
 
-  As part of this update, transactions can now include a new optional field: `timestampMs`.
+  Before this upgrade, delegate ranking was based on raw vote weight — the total ADM staked by all voters who voted for each delegate. This allowed large holders to dominate the active delegate set disproportionately.
 
-  - `timestampMs` is a timestamp in milliseconds.
-  - It shows when the transaction was created on the **client side**.
-  - This field is **optional**. Transactions without it are still valid.
-  - If included, the field must be close to the `timestamp`. If it's too far in the past or future, the transaction may be rejected.
+  The `fairSystem` upgrade replaces raw `vote` with **productivity-adjusted `votesWeight`** for delegate ranking, active-delegate selection, and approval calculation:
 
-  This change improves the user experience and ensures the correct order of messages.
+  - Each voter's balance is divided proportionally across all delegates they voted for (so voting for more delegates dilutes each vote).
+  - The resulting per-delegate weight is then multiplied by that delegate's **productivity** (the fraction of their scheduled block slots that they successfully forged).
+  - Delegates with low productivity receive less effective voting weight, incentivizing consistent block production.
+  - The approval percentage shown for a delegate is calculated as their adjusted `votesWeight` divided by the current token supply.
+
+  This makes voting influence fairer while keeping delegate ordering deterministic.
+
+- **Pre-activation behavior**
+
+  Before height `4,359,465`, delegate ranking uses raw `vote` totals. API responses for delegates include the `vote` field.
+
+- **Post-activation behavior**
+
+  From height `4,359,465` onward, delegate ranking uses `votesWeight`. API responses include the `votesWeight` field for ranking and approval calculations.
+
+## spaceship
+
+- **Target block for activation:** `100,000,000` (mainnet)
+
+- **Description**
+
+  Transactions can now include a new optional field: `timestampMs`.
+
+  - `timestampMs` is a client-side timestamp in milliseconds, using the same ADAMANT epoch as `timestamp` (seconds since September 2, 2017, 17:00:00 UTC).
+  - It records when the transaction was **created on the client side**, providing sub-second ordering precision.
+  - This field is **optional**. Transactions without it remain valid.
+  - If included, `timestampMs` must be within the same ADAMANT second as `timestamp` (i.e., `Math.floor(timestampMs / 1000) === timestamp`). Transactions that violate this constraint are rejected.
+
+  Before this upgrade, nodes strip `timestampMs` from transactions during normalization to preserve compatibility. After activation, nodes preserve and return `timestampMs` for transactions that include it.
+
+  This change improves the display order of messages and events in messenger applications.
 
 - **Example**
 
   ```json
   {
-    // ...
     "timestamp": 1716829200,
-    "timestampMs": 1716829200000,
+    "timestampMs": 1716829200456,
     "signature": "..."
   }
   ```
+
+- **Client compatibility note**
+
+  Historical transactions and transactions from older clients may have `timestampMs: null`. Clients should prefer `timestampMs` for ordering when it is present and fall back to `timestamp * 1000` otherwise.
+
+  See [Core Concepts — Timestamps](/core-concepts.md#timestamps) for the conversion formulas.

--- a/own-node/installation.md
+++ b/own-node/installation.md
@@ -9,31 +9,38 @@ The following guide is for **Ubuntu Linux**. For more detailed guides on differe
 
 ## Requirements
 
-- **Ubuntu** v18.04–v24.04 (other versions are not tested)
+- **Ubuntu** v20.04–v26.04 LTS (other versions are not tested)
+- **Node.js** v22.13.0 or newer
 - **RAM**: 2 GB or more
-- **Disk space**: A minimum of 70 GB as of June 2025 (mainnet)
+- **Disk space**: A minimum of 70 GB as of June 2026 (mainnet)
   - Expect the blockchain to grow by approximately _10 GB per year_
 
 ## Installation script
 
-For new servers, use the [Installation script](https://github.com/Adamant-im/adamant/blob/dev/tools/install_node.sh) from official repository, or fetch it directly from the ADAMANT website:
+For new servers, use the [Installation script](https://github.com/Adamant-im/adamant/blob/dev/tools/install_node.sh) from the official repository, or fetch it directly from the ADAMANT website:
 
 ```sh
 sudo bash -c "$(wget -O - https://adamant.im/install_node.sh)"
 ```
 
-The script updates Ubuntu packages, creates a dedicated user named `adamant`, sets up a new PostgreSQL database, installs Node.js and other necessary dependencies, configures the ADAMANT mainnet/testnet node, and optionally downloads an up-to-date ADAMANT blockchain image.
+The script updates Ubuntu packages, creates a dedicated user named `adamant`, sets up a new PostgreSQL database, installs Node.js and other necessary dependencies, configures the ADAMANT mainnet/testnet node, and optionally downloads an up-to-date ADAMANT blockchain image. It preserves existing configuration files and local Git changes, and reuses existing users and databases.
 
 Script parameters:
 
 - `-b`: The GitHub branch from which the ADAMANT node will be installed. Default is `master`.
 - `-n`: The ADAMANT blockchain network (`mainnet` or `testnet`). Default is `mainnet`.
-- `-j`: The Node.js version (`iron`=20 or `jod`=22). Default is `jod`.
+- `-j`: The Node.js version (`22`, `jod`=22, `24`, `krypton`=24, or `26`). Default is `24`.
 
 For example:
 
 ```sh
-sudo bash -c "$(wget -O - https://adamant.im/install_node.sh)" -O -b dev -n testnet -j jod
+sudo bash -c "$(wget -O - https://adamant.im/install_node.sh)" -O -b dev -n testnet -j 24
+```
+
+A RHEL-compatible installer (CentOS Stream, Rocky Linux, AlmaLinux, RHEL 8–10) is also available:
+
+```sh
+sudo bash -c "$(wget -O - https://adamant.im/install_node_centos.sh)" -O -b dev -n mainnet -j 24
 ```
 
 ## Manual Installation
@@ -48,7 +55,7 @@ If you are an experienced Linux user and want more control over installation, yo
   sudo apt-get install -y python build-essential curl automake autoconf libtool
   ```
 
-- **Git** — Used for cloning and updating ADAMANT GitHub repository
+- **Git** — Used for cloning and updating the ADAMANT GitHub repository
 
   ```sh
   sudo apt-get install -y git
@@ -66,8 +73,8 @@ If you are an experienced Linux user and want more control over installation, yo
   - Or locally, using [nvm](https://github.com/nvm-sh/nvm):
 
     ```sh
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-    nvm i --lts=jod #Node.js 22 LTS
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash
+    nvm install --lts=krypton  # Node.js 24 LTS
     ```
 
 - **PostgreSQL** — Database engine to store blockchain data
@@ -130,7 +137,7 @@ nano config.json
 
 Make the necessary changes to the configuration values in the file. At minimum, you should change the value of the `db.password` property to your actual database password.
 
-See [Configuration](./configuration) for description of every configuration file property.
+See [Configuration](./configuration) for a description of every configuration file property.
 
 ### Bootstrap with a blockchain image/snapshot
 
@@ -145,7 +152,7 @@ psql adamant_main < db_backup.sql
 rm db_backup.sql
 ```
 
-(This example is for mainnet ADM node. For testnet, use the image url: https://testnet.adamant.im/db_test_backup.sql.gz)
+(This example is for the mainnet ADM node. For testnet, use the image URL: https://testnet.adamant.im/db_test_backup.sql.gz)
 
 Bootstrapping typically takes up to 20 minutes but can save you several days of synchronization time.
 
@@ -157,7 +164,7 @@ To verify that everything is set up correctly, start the node temporarily in the
 node app.js
 ```
 
-If everything is working properly, you’ll see log output indicating that the blockchain is syncing and the node height is increasing.
+If everything is working properly, you'll see log output indicating that the blockchain is syncing and the node height is increasing.
 
 Next, run the ADM node using pm2:
 
@@ -171,7 +178,7 @@ Check that the node is running smoothly:
 pm2 logs adamant
 ```
 
-You can also verify the node’s block height and status with simple API requests:
+You can also verify the node's block height and status with simple API requests:
 
 ```sh
 curl http://localhost:36666/api/blocks/getHeight
@@ -186,11 +193,17 @@ crontab -l | { cat; echo "@reboot cd /home/adamant/adamant && pm2 start --name a
 
 Alternatively, you can use pm2's built-in startup functionality: `pm2 save` — `pm2 startup`.
 
+::: warning Critical Shutdown Notice
+Always stop the node gracefully. When running it in the foreground, press `Ctrl+C` and wait for cleanup to finish. Do not use `kill -9` or any other forced termination unless the process is already unrecoverably stuck.
+
+The node stores derived consensus state in memory tables (`mem_accounts`, `mem_round`). A forced kill can leave these inconsistent with the persisted blockchain, forcing a full rebuild from genesis on the next startup.
+:::
+
 ### Recovering an ADAMANT node
 
-It may happen that your ADM node lost the current blockchain height and restarted, rising from the beginning. The most common reasons are a hardware error or lack of disk space. Though validating blocks from 0 height is a decent option, catching up with the current height may take several days.
+It may happen that your ADM node lost the current blockchain height and restarted from the beginning. The most common reasons are a hardware error or lack of disk space. Although validating blocks from height 0 is a valid option, catching up with the current height may take several days.
 
-If you probably prefer using an up-to-date blockchain image and enabling it back in ten minutes, run this script:
+If you prefer to use an up-to-date blockchain image and restore the node in minutes, run this script:
 
 ```sh
 sudo bash -c "$(wget -O - https://adamant.im/fix_node.sh)" -O -n mainnet
@@ -199,5 +212,7 @@ sudo bash -c "$(wget -O - https://adamant.im/fix_node.sh)" -O -n mainnet
 Script parameters:
 
 - `-n`: The ADAMANT blockchain network (`mainnet` or `testnet`). Default is `mainnet`.
+
+The repair tool drops the database to free disk space, downloads and validates the replacement image, then recreates the database and restores it from the snapshot. Back up any required data first.
 
 Alternatively, follow the recovery steps manually.

--- a/own-node/localnet.md
+++ b/own-node/localnet.md
@@ -1,0 +1,117 @@
+# Localnet
+
+A localnet runs multiple ADAMANT nodes on one machine without connecting to any public peers. It is useful when you need an isolated environment to test consensus behavior, transaction handling, or multi-node scenarios.
+
+::: tip
+For single-node local testing against testnet peers, use [Testnet](./testnet.md) instead. Localnet is designed for multi-node isolation.
+:::
+
+## Starting a Localnet
+
+Start a localnet with a given number of nodes:
+
+```sh
+npm run start:localnet -- --nodes 3
+```
+
+Each node gets isolated ports, PostgreSQL database names, Redis database indexes, process output files, and ADAMANT log files.
+
+`start:localnet` uses the following defaults:
+
+- `test/config.default.json` as the base config
+- `test/genesisBlock.json` as the genesis block
+- `test/genesisPasses.json` as the genesis delegate passphrase source
+- `test/config.localnet.json` as additional config overrides
+- One generated per-node override file under `.localnet/node-N/`
+
+The localnet manifest is written to `.localnet/manifest.json` and includes node endpoints, PIDs, database names, Redis URLs, log paths, and delegate counts.
+
+## Managing the Localnet
+
+**Check status:**
+
+```sh
+npm run status:localnet
+```
+
+Reports each managed node's height, loader state, cached and live broadhash consensus, configured delegate counts, and last forging timestamp.
+
+**Stop nodes:**
+
+```sh
+npm run stop:localnet
+```
+
+Sends `SIGTERM` to every managed node and waits for graceful shutdown. Databases are not dropped by default.
+
+**Stop and drop databases in one step:**
+
+```sh
+npm run stop:localnet -- --drop-on-stop
+```
+
+**Drop databases without stopping (e.g., for a clean restart):**
+
+```sh
+npm run drop:localnet
+```
+
+Drops the isolated PostgreSQL databases and flushes only the Redis databases assigned to localnet nodes.
+
+## Log Layout
+
+```
+logs-localnet/
+  node-1/
+    adamant_localnet.log
+    adamant_localnet_debug.log
+  node-2/
+  node-3/
+```
+
+## PostgreSQL Databases
+
+By default, `start:localnet` tries to create missing per-node databases:
+
+```
+adamant_localnet_node_1
+adamant_localnet_node_2
+adamant_localnet_node_3
+```
+
+Databases are owned by the configured DB user (`adamanttest` by default). If your local PostgreSQL user cannot create databases, pass a PostgreSQL admin user:
+
+```sh
+npm run start:localnet -- --nodes 3 --db-admin-user postgres
+```
+
+Or create the databases manually and start with `--skip-db-create`.
+
+## Delegate Distribution
+
+By default, genesis delegate passphrases are distributed evenly across nodes. For one to three nodes, all nodes receive delegate passphrases. For more than three nodes, the last node is non-forging and the remaining nodes share the passphrases as evenly as possible.
+
+## Configuration Overrides
+
+You can override localnet configuration values at startup. For example, to set custom consensus activation heights for testing:
+
+```sh
+npm run start:localnet -- --nodes 3 \
+  --config-set consensusActivationHeights.fairSystem=203 \
+  --config-set consensusActivationHeights.spaceship=405
+```
+
+See [Configuration Overrides](./configuration.md#configuration-overrides) for the full syntax.
+
+## Nethash
+
+Localnet uses the testnet genesis block by default. The node derives `nethash` from `genesisBlock.payloadHash` — the SHA-256 payload hash of the genesis block transactions. All localnet nodes must use the same genesis block.
+
+## Running Scenario Tests Against Localnet
+
+```sh
+npm run start:localnet -- --nodes 3
+npm run scenario:localnet -- --all
+```
+
+For more details on available scenarios, refer to [CONTRIBUTING.md](https://github.com/Adamant-im/adamant/blob/dev/.github/CONTRIBUTING.md).

--- a/own-node/syncing.md
+++ b/own-node/syncing.md
@@ -37,7 +37,7 @@ If a peer is connected via WebSocket, it may still receive the same transaction 
 
 As a result, a node may receive the same unconfirmed transaction multiple times, from different peers, and through both REST and WebSocket. This helps ensure that transactions reliably reach their destination even if some connections fail.
 
-## Backward compability
+## Backward compatibility
 
 In earlier versions, nodes had a separate WebSocket server intended for transaction syncing, but it wasn't fully implemented and didn't receive transactions over WebSocket.
 

--- a/own-node/testnet.md
+++ b/own-node/testnet.md
@@ -1,6 +1,6 @@
 # Testnet
 
-You may want to test the node in a safe environment before running a `mainnet` node. The `testnet` configuration allows to experiment and run tests without affecting the `mainnet`.
+You may want to test the node in a safe environment before running a mainnet node. The `testnet` configuration lets you experiment and run tests without affecting the mainnet.
 
 ## Installation
 
@@ -9,15 +9,14 @@ You may want to test the node in a safe environment before running a `mainnet` n
   You can use the [installation script](./installation.md#installation-script) to automatically install the node for testnet:
 
   ```sh
-  # Fetches the script and install the latest stable ADAMANT version using testnet config
-  sudo bash -c "$(wget -O - https://adamant.im/install_node.sh)" -O -b master -n testnet -j jod
+  sudo bash -c "$(wget -O - https://adamant.im/install_node.sh)" -O -b master -n testnet -j 24
   ```
 
-  This will create `test/config.json` file, which you can edit as needed.
+  This will create a `test/config.json` file, which you can edit as needed.
 
-- **Manually setup**
+- **Manual setup**
 
-  To manually set up and run a local test node, copy the default config file and edit your copy:
+  To manually set up and run a local testnet node, copy the default config file and edit your copy:
 
   ```sh
   cp test/config.default.json test/config.json
@@ -31,6 +30,14 @@ To start the testnet node:
 npm run start:testnet
 ```
 
+You can also override individual configuration values at startup without editing `test/config.json`. For example, to enable public API access:
+
+```sh
+npm run start:testnet -- --config-set api.access.public=true
+```
+
+See [Configuration Overrides](./configuration.md#configuration-overrides) for the full override syntax.
+
 ## Running tests
 
 Refer to [CONTRIBUTING.md](https://github.com/Adamant-im/adamant/blob/dev/.github/CONTRIBUTING.md).
@@ -39,6 +46,6 @@ Refer to [CONTRIBUTING.md](https://github.com/Adamant-im/adamant/blob/dev/.githu
 
 - A bootstrap snapshot of the testnet database is available for download (the installation script also supports bootstrapping): https://testnet.adamant.im/db_test_backup.sql.gz
 - The testnet explorer: [testnet.adamant.im](https://testnet.adamant.im/)
-- Request testnet ADM coins (3500 ADM) via the same faucet as mainnet: [Faucet](https://adamant.im/free-adm-tokens/)
-- Access the testnet messenger app (dev branch autobuild): [Testnet messenger](https://dev-adamant-testnet.surge.sh/)
-- You can view the IPs and ports of testnet nodes in the [test/config.default.json](https://github.com/Adamant-im/adamant/blob/dev/test/config.default.json) file.
+- Request testnet ADM coins (3500 ADM) via the faucet: [Faucet](https://adamant.im/free-adm-tokens/)
+- Access the testnet messenger app (dev branch build): [Testnet messenger](https://dev-adamant-testnet.surge.sh/)
+- View the IPs and ports of testnet peers in [test/config.default.json](https://github.com/Adamant-im/adamant/blob/dev/test/config.default.json).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "adamant-docs",
       "dependencies": {
-        "vitepress": "^1.6.3"
+        "vitepress": "^1.6.4"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -304,351 +304,6 @@
         }
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.29",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.29.tgz",
@@ -668,240 +323,325 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.37.0.tgz",
-      "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.37.0.tgz",
-      "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.37.0.tgz",
-      "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.37.0.tgz",
-      "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.37.0.tgz",
-      "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.37.0.tgz",
-      "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.37.0.tgz",
-      "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.37.0.tgz",
-      "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.37.0.tgz",
-      "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.37.0.tgz",
-      "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.37.0.tgz",
-      "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.37.0.tgz",
-      "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.37.0.tgz",
-      "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.37.0.tgz",
-      "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.37.0.tgz",
-      "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
-      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.37.0.tgz",
-      "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.37.0.tgz",
-      "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.37.0.tgz",
-      "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.37.0.tgz",
-      "integrity": "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -979,9 +719,10 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1386,43 +1127,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -1522,9 +1226,10 @@
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -1636,15 +1341,16 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1673,9 +1379,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1690,8 +1396,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1744,11 +1451,12 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rollup": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
-      "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1758,26 +1466,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.37.0",
-        "@rollup/rollup-android-arm64": "4.37.0",
-        "@rollup/rollup-darwin-arm64": "4.37.0",
-        "@rollup/rollup-darwin-x64": "4.37.0",
-        "@rollup/rollup-freebsd-arm64": "4.37.0",
-        "@rollup/rollup-freebsd-x64": "4.37.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.37.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.37.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.37.0",
-        "@rollup/rollup-linux-arm64-musl": "4.37.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.37.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.37.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.37.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.37.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.37.0",
-        "@rollup/rollup-linux-x64-gnu": "4.37.0",
-        "@rollup/rollup-linux-x64-musl": "4.37.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.37.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.37.0",
-        "@rollup/rollup-win32-x64-msvc": "4.37.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -1955,9 +1668,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
-      "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2012,10 +1726,468 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/vitepress": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.3.tgz",
-      "integrity": "sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "license": "MIT",
       "dependencies": {
         "@docsearch/css": "3.8.2",
         "@docsearch/js": "3.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,13 @@
 {
   "name": "adamant-docs",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adamant-docs",
+      "version": "0.10.0",
+      "license": "GPL-3.0",
       "dependencies": {
         "vitepress": "^1.6.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,28 @@
 {
   "name": "adamant-docs",
+  "version": "0.10.0",
+  "description": "Documentation for ADAMANT Node and API",
+  "keywords": [
+    "adm",
+    "adamant",
+    "blockchain",
+    "messenger",
+    "messaging",
+    "decentralization",
+    "privacy",
+    "encryption",
+    "crypto",
+    "cryptocurrency",
+    "dpos",
+    "docs"
+  ],
+  "author": "ADAMANT community developers <devs@adamant.im>",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Adamant-im/docs.git"
+  },
+  "homepage": "https://docs.adamant.im",
   "scripts": {
     "docs:build": "vitepress build",
     "docs:preview": "vitepress preview",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "dev": "vitepress dev"
   },
   "dependencies": {
-    "vitepress": "^1.6.3"
+    "vitepress": "^1.6.4"
+  },
+  "overrides": {
+    "esbuild": "~0.25.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["vitepress/client"]
+  },
+  "include": [
+    ".vitepress/**/*.ts",
+    ".vitepress/**/*.mts",
+    ".vitepress/**/*.vue"
+  ]
+}


### PR DESCRIPTION
## Description

Update the ADAMANT documentation site to align with the ADAMANT Node v0.10.0 release. This covers all major changes introduced in the node: new consensus activation heights, localnet support, configuration overrides, updated installation requirements, and revised logging structure. Adds an SDK section to the sidebar and fixes several grammar issues throughout.

**Changes by area:**

- **`own-node/installation.md`** — Node.js 24 as the default runtime (nvm 0.40.5, krypton alias); Node.js 22/24/26 listed as supported; CentOS/RHEL installer added; Critical Shutdown Notice callout.
- **`own-node/configuration.md`** — New `consensusActivationHeights` property (`fairSystem`, `spaceship`); new `cacheEnabled` and `topAccounts` options; updated logging structure (`generalLog`, `debugLog`, `consoleLog` with `rotate`); `--config-set` and `--config-overrides` CLI flags documented with examples.
- **`own-node/consensus.md`** — Added DPoS introduction; `fairSystem` section (activation height 4,359,465, `votesWeight` formula); expanded `spaceship` section with full constraint semantics and client compatibility note; `consensusActivationHeights` override examples.
- **`own-node/testnet.md`** — Node.js 24 default; `--config-set` override example added; grammar fixes.
- **`own-node/localnet.md`** (new) — Full localnet docs: `npm run start:localnet -- --nodes N`, status/stop/drop commands, log layout, PostgreSQL DB setup, delegate distribution, config overrides, and scenario tests.
- **`own-node/syncing.md`** — Typo fix: "Backward compability" → "Backward compatibility".
- **`core-concepts.md`** — Added "Blocks and Rounds" and "Delegates and Voting" sections.
- **`index.md`** — Grammar fixes; Localnet mention.
- **`README.md`** — Added Links section: ADAMANT website, Node repo, AIPs, API Schema Swagger, API Schema source.
- **`.vitepress/config.mts`** — Localnet page added to sidebar; SDK section added (JS API Client, Console Tool, API Schema); API Schema nav link updated to `https://schema.adamant.im/`.
- **`.vitepress/theme/SidebarVersion.vue`** (new) — Version badge in the nav bar title area, sourced from `package.json`.
- **`.vitepress/theme/index.ts`** — Registers `SidebarVersion` via `nav-bar-title-after` layout slot.
- **`tsconfig.json`** (new) — Resolves editor TS errors: `moduleResolution: "Bundler"`, `resolveJsonModule: true`, `types: ["vitepress/client"]`.
- **`package.json`** — Version bumped to `0.10.0`; added `description`, `keywords`, `author`, `license`, `repository`, `homepage`; `esbuild` overridden to `~0.25.0` to fix transitive vulnerability.
- **`package-lock.json`** — Regenerated; vulnerability count reduced from 5 to 2 (remaining 2 are Windows-only vite dev-server issues with no upstream fix in vitepress 1.6.4).

## Related issue

Closes #22

## How to test

1. `npm install && npm run dev`
2. Verify version badge appears inline with "ADAMANT Docs" in the nav bar.
3. Check sidebar: "Localnet" appears under "Running Own Node" after "Testnet"; "SDK" section appears after "Examples".
4. Navigate to each updated page and confirm accuracy against [ADAMANT Node v0.10.0 source](https://github.com/Adamant-im/adamant).
5. `npm run docs:build` — build must complete without errors.
6. `npm audit` — 2 moderate vulnerabilities (Windows-only, no fix available upstream).

## Checklist

- [x] Documentation is accurate and matches Node v0.10.0 source (`config.default.json`, `helpers/constants.js`, `CONTRIBUTING.md`)
- [x] Build passes without errors
- [x] No new TS errors in `.vitepress/`
- [x] `tsconfig.json` added to resolve editor diagnostics
- [x] npm vulnerabilities reduced (5 → 2); remaining 2 have no upstream fix
- [x] Localnet page added per `CONTRIBUTING.md` instructions
- [x] Sidebar order: Localnet after Testnet; SDK section after Examples
