### PR TITLE
Docs: Add top accounts API reference

### DIFF
--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -187,7 +187,7 @@ GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
   Request:
 
   ```sh
-  GET https://endless.adamant.im/api/accounts/top?limit=2&offset=0&isDelegate=1
+  GET https://endless.adamant.im/api/accounts/top?limit=1&offset=0&isDelegate=1
   ```
 
   Response:

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -169,8 +169,10 @@ GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
 
 - **Description**
 
-  Returns accounts sorted by confirmed `balance` in descending order. Accounts with the same balance are sorted by
-  `address` in ascending order, so pagination stays stable between requests.
+  Returns non-zero-balance accounts sorted by confirmed `balance` in descending order. Accounts with the same balance
+  are sorted by `address` in ascending order, so pagination stays stable between requests.
+
+  The `count` field reports how many non-zero-balance accounts match the current filter before pagination is applied.
 
   This endpoint is available on every node that supports it; it does not require a node-side feature flag.
 

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -206,7 +206,7 @@ GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
       }
     ],
     "count": 254,
-    "limit": 2,
+    "limit": 1,
     "offset": 0
   }
   ```

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -161,6 +161,56 @@ GET /api/accounts/getPublicKey?address={ADAMANT address}
   }
   ```
 
+## Get Top Accounts
+
+```sh
+GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
+```
+
+- **Description**
+
+  Returns accounts sorted by confirmed `balance` in descending order. Accounts with the same balance are sorted by
+  `address` in ascending order, so pagination stays stable between requests.
+
+  This endpoint is available on every node that supports it; it does not require a node-side feature flag.
+
+- **Parameters**
+
+  | Parameter    | Type    | Required | Description                                                                                                                       |
+  | ------------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+  | `limit`      | integer | No       | Number of accounts to return. Default is `100`, maximum is `100`. Use `0` to return only `count`, `limit`, and `offset` metadata. |
+  | `offset`     | integer | No       | Number of sorted accounts to skip. Default is `0`.                                                                                |
+  | `isDelegate` | integer | No       | Filter by delegate status. Use `1` for delegate accounts and `0` for non-delegate accounts.                                       |
+
+- **Example**
+
+  Request:
+
+  ```sh
+  GET https://endless.adamant.im/api/accounts/top?limit=2&offset=0&isDelegate=1
+  ```
+
+  Response:
+
+  ```jsonc
+  {
+    "success": true,
+    "nodeTimestamp": 63205623,
+    "accounts": [
+      {
+        "address": "U777355171330060015",
+        "balance": "4509718944753",
+        "publicKey": "a9407418dafb3c8aeee28f3263fd55bae0f528a5697a9df0e77e6568b19dfe34",
+        "username": "adamant_delegate",
+        "isDelegate": 1
+      }
+    ],
+    "count": 254,
+    "limit": 2,
+    "offset": 0
+  }
+  ```
+
 ## Create New Account
 
 ```sh

--- a/api/transactions-query-language.md
+++ b/api/transactions-query-language.md
@@ -302,7 +302,7 @@ You can filter by single parameter, or by multiple parameters. Default condition
 
 Options always joined with `and` condition.
 
-For confirmed transactions, the node composes supported filters into one flat SQL `WHERE` expression:
+For confirmed transactions, you can prefix filters with `and:` or `or:` to control how they are joined, and the node composes the resulting filter chain into one flat SQL `WHERE` expression:
 
 1. Filters are appended in the same order in which they appear in the query string.
 2. The first filter starts the expression, so its `and:` or `or:` prefix does not change the result.

--- a/api/transactions-query-language.md
+++ b/api/transactions-query-language.md
@@ -302,6 +302,36 @@ You can filter by single parameter, or by multiple parameters. Default condition
 
 Options always joined with `and` condition.
 
+For confirmed transactions, the node composes supported filters into one flat SQL `WHERE` expression:
+
+1. Filters are appended in the same order in which they appear in the query string.
+2. The first filter starts the expression, so its `and:` or `or:` prefix does not change the result.
+3. The node does not add grouping parentheses around mixed `and:`/`or:` conditions.
+4. Standard SQL precedence applies inside the flat expression: `AND` is evaluated before `OR`.
+
+This makes parameter order significant. The same filters can return different transactions when they are reordered:
+
+| Query string | Effective condition |
+| --- | --- |
+| `and:inId=U100739400829575109&and:minAmount=1&or:types=0,1,2,3,4,5,6,7` | `(inId AND minAmount) OR types` |
+| `or:types=0,1,2,3,4,5,6,7&and:inId=U100739400829575109&and:minAmount=1` | `types AND inId AND minAmount` |
+| `or:minAmount=1&and:types=0,1,2,3,4,5,6,7` | `minAmount AND types` |
+| `and:types=0,1,2,3,4,5,6,7&or:minAmount=1` | `types OR minAmount` |
+
+Grouping is not supported. You can express `(A AND B) OR C` by placing the `or:` condition after the
+`and:` conditions, but you cannot express `A AND (B OR C)` in one request.
+
+Be careful when adding `or:` filters to an address filter. For example, this request returns transactions for
+`U100739400829575109` with a positive amount and also every transaction of types `0` through `7`, including
+transactions unrelated to that address:
+
+```url
+https://endless.adamant.im/api/transactions?and:inId=U100739400829575109&and:minAmount=1&or:types=0,1,2,3,4,5,6,7
+```
+
+If the address must apply to all returned transactions, keep every additional filter joined with `and:` or make
+separate requests for logical shapes that need grouping.
+
 - **Examples**
 
   Get transactions where height greater than `1336065` **or** `blockId = 7917597195203393333`:

--- a/own-node/configuration.md
+++ b/own-node/configuration.md
@@ -200,18 +200,6 @@ Possible log levels (from least to most verbose):
 
   Cache is disabled by default on mainnet and enabled on testnet. Enabling it can improve API response times for high-traffic public nodes.
 
-- **Top Accounts**
-
-  Enable the `/api/accounts/top` endpoint (returns accounts sorted by balance) with `topAccounts`:
-
-  ```json
-  {
-    "topAccounts": false
-  }
-  ```
-
-  This endpoint is disabled by default on mainnet. Enabling it on a high-traffic node may have a performance impact.
-
 ## Database Configuration
 
 - **Database Connection**


### PR DESCRIPTION
## Description

Documents the new `GET /api/accounts/top` endpoint from Adamant-im/adamant#257:

- adds an Accounts API reference section with parameters, sorting behavior, and response example
- documents `limit`, `offset`, and `isDelegate`
- removes the obsolete `topAccounts` configuration flag from the node configuration page because the endpoint is registered unconditionally

Also expands the Transactions Query Language page for Adamant-im/docs#28:

- explains that confirmed transaction filters are composed as one flat, ordered SQL `WHERE` expression
- documents the first-filter behavior, SQL `AND`/`OR` precedence, and the lack of grouping support
- adds worked examples, including the address-filter leak case when an `or:` condition is appended to an address filter

Node implementation PR: Adamant-im/adamant#260.

Schema companion PR: Adamant-im/adamant-schema#44.

## Related issue

Closes #28.

Related to Adamant-im/adamant#257.

Related downstream issues:

- Adamant-im/adamant-api-jsclient#87
- Adamant-im/adamant-explorer#11

## How to test

Passed:

- `npm run docs:build`
- `git diff --check`
- Local preview check for `/api/transactions-query-language.html#combine-filters-and-options`: the new SQL precedence text, four-row examples table, and address-filter warning render on the page

Note: the local preview also emits an existing VitePress hydration mismatch warning, which reproduces on the homepage and is not caused by this page change.

## Checklist

- [x] Targets `dev`
- [x] Endpoint documentation matches the node implementation in Adamant-im/adamant#257
- [x] Transactions Query Language behavior was checked against the ADAMANT node implementation
- [x] No sidebar update needed because this changes existing pages only
- [x] Obsolete config documentation removed
- [x] Repository artifacts are in English