### PR TITLE
Docs: Align blocks API reference with node behavior

### DIFF
--- a/api-endpoints/blocks.md
+++ b/api-endpoints/blocks.md
@@ -74,7 +74,9 @@ GET /api/blocks
 
 - **Description**
 
-  Get a list of blocks from the ADAMANT blockchain using the `/api/blocks/` endpoint. Returns an array of [blocks](#get-block-by-id) from newest to oldest.
+  Get a list of blocks from the ADAMANT blockchain using the `/api/blocks/` endpoint. Returns an
+  array of [blocks](#get-block-by-id) ordered by `orderBy` (default: `height:desc`, from newest to
+  oldest).
 
   Available parameters:
 
@@ -87,9 +89,9 @@ GET /api/blocks
   | `numberOfTransactions` | Exact non-negative number of transactions in the block |
   | `previousBlock` | ID of the preceding block |
   | `height` | Exact positive block height |
-  | `totalAmount` | Exact non-negative total amount transferred by the block's transactions, in 1/10^8 ADM |
-  | `totalFee` | Exact non-negative total transaction fee, in 1/10^8 ADM |
-  | `reward` | Exact non-negative forging reward, in 1/10^8 ADM |
+  | `totalAmount` | Exact non-negative integer amount of 1/10^8 ADM tokens transferred within all transactions in the block |
+  | `totalFee` | Exact non-negative integer amount of 1/10^8 ADM tokens paid as transaction fees in the block |
+  | `reward` | Exact non-negative integer amount of 1/10^8 ADM tokens created as the forging reward |
 
   `orderBy` accepts `asc` or `desc` for the following fields: `id`, `timestamp`, `height`,
   `previousBlock`, `totalAmount`, `totalFee`, `reward`, `numberOfTransactions`, and

--- a/api-endpoints/blocks.md
+++ b/api-endpoints/blocks.md
@@ -49,7 +49,6 @@ GET /api/blocks/get?id={block's id}
       "id": "11114690216332606721",
       "version": 0,
       "timestamp": 61741820,
-      "timestampMs": null,
       "height": 10873829,
       "previousBlock": "11483763337863654141",
       "numberOfTransactions": 1,
@@ -79,10 +78,22 @@ GET /api/blocks
 
   Available parameters:
 
-  - `limit` — number of blocks to retrieve (default: 100)
-  - `offset` — height offset value for results (default: 0)
-  - `generatorPublicKey` — public key of the delegate who generated the block
-  - `height` — specific block height
+  | Parameter | Description |
+  | --- | --- |
+  | `limit` | Number of blocks to retrieve, from 1 to 100 (default: 100) |
+  | `offset` | Number of rows to skip after applying the requested order, starting from 0 (default: 0) |
+  | `orderBy` | Sort expression in `field:direction` form (default: `height:desc`) |
+  | `generatorPublicKey` | 64-character hexadecimal public key of the delegate who generated the block |
+  | `numberOfTransactions` | Exact non-negative number of transactions in the block |
+  | `previousBlock` | ID of the preceding block |
+  | `height` | Exact positive block height |
+  | `totalAmount` | Exact non-negative total amount transferred by the block's transactions, in 1/10^8 ADM |
+  | `totalFee` | Exact non-negative total transaction fee, in 1/10^8 ADM |
+  | `reward` | Exact non-negative forging reward, in 1/10^8 ADM |
+
+  `orderBy` accepts `asc` or `desc` for the following fields: `id`, `timestamp`, `height`,
+  `previousBlock`, `totalAmount`, `totalFee`, `reward`, `numberOfTransactions`, and
+  `generatorPublicKey`.
 
 - **Example**
 
@@ -103,7 +114,6 @@ GET /api/blocks
         "id": "15416108601994762552",
         "version": 0,
         "timestamp": 58045350,
-        "timestampMs": null,
         "height": 10144920,
         "previousBlock": "16611488400968379374",
         "numberOfTransactions": 0,
@@ -122,7 +132,6 @@ GET /api/blocks
         "id": "16611488400968379374",
         "version": 0,
         "timestamp": 58045345,
-        "timestampMs": null,
         "height": 10144919,
         "previousBlock": "17869865393675106520",
         "numberOfTransactions": 0,


### PR DESCRIPTION
## Description

Align the blocks API reference with the current ADAMANT Node `dev` behavior.

The page now documents every supported `GET /api/blocks` filter, the exact `limit` and row-based `offset` semantics, the `orderBy` syntax, all sortable fields, and accepted sort directions. It also removes `timestampMs: null` from block response examples because the blocks API does not return that field.

## Related issue

Closes #32

## External links (optional)

- Node performance bug: https://github.com/Adamant-im/adamant/issues/258
- Node implementation: https://github.com/Adamant-im/adamant/pull/263
- Schema issue: https://github.com/Adamant-im/adamant-schema/issues/45
- Schema PR: https://github.com/Adamant-im/adamant-schema/pull/46

## Screenshots or videos (optional)

Not applicable; this is a content-only API reference update.

## Breaking changes

None. The change documents existing behavior and removes fields that were not part of the actual blocks API response.

## How to test

```sh
npm run docs:build
```

Open `/api-endpoints/blocks` and verify that:

1. The parameter table includes every filter supported by the node.
2. `offset` is described as a row offset applied after ordering.
3. `orderBy` documents its syntax, directions, and allowed fields.
4. Block examples no longer include `timestampMs`.

## Notes for reviewers

- No sidebar update is required because the existing page path is unchanged.
- The documented parameter names and sort fields were checked against `schema/blocks.js`, `modules/blocks/api.js`, and `sql/blocks.js` in ADAMANT Node `dev`.
- The OpenAPI schema is updated in companion PR https://github.com/Adamant-im/adamant-schema/pull/46.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
