### PR TITLE
Docs: Document status schedules and delegate API enhancements

### DIFF
--- a/api-endpoints/blockchain.md
+++ b/api-endpoints/blockchain.md
@@ -598,7 +598,8 @@ GET /api/blocks/getStatus
   - [`broadhash`](#get-blockchain-broadhash)
   - [`epoch`](#get-blockchain-epoch)
   - [`height`](#get-blockchain-height)
-  - `consensusCodeName` — latest consensus upgrade active at `height`, or `null` before the first configured activation
+  - `consensusCodeName` — latest consensus upgrade active at `height`, or `null` before the first configured
+    activation
   - [`fee`](#get-blockchain-fee)
   - [`milestone`](#get-blockchain-milestone)
   - [`nethash`](#get-blockchain-nethash)

--- a/api-endpoints/blockchain.md
+++ b/api-endpoints/blockchain.md
@@ -598,7 +598,7 @@ GET /api/blocks/getStatus
   - [`broadhash`](#get-blockchain-broadhash)
   - [`epoch`](#get-blockchain-epoch)
   - [`height`](#get-blockchain-height)
-  - `consensus` — latest consensus upgrade active at `height`, or `null` before the first configured activation
+  - `consensusCodeName` — latest consensus upgrade active at `height`, or `null` before the first configured activation
   - [`fee`](#get-blockchain-fee)
   - [`milestone`](#get-blockchain-milestone)
   - [`nethash`](#get-blockchain-nethash)
@@ -622,7 +622,7 @@ GET /api/blocks/getStatus
     "broadhash": "4a28272c915f74d118120bb47db547a18a7512e1d48092c48be86939a6d45b89",
     "epoch": "2017-09-02T17:00:00.000Z",
     "height": 10145334,
-    "consensus": "fairSystem",
+    "consensusCodeName": "fairSystem",
     "fee": 50000000,
     "milestone": 1,
     "nethash": "bd330166898377fb28743ceef5e43a5d9d0a3efd9b3451fb7bc53530bb0a6d64",
@@ -639,12 +639,16 @@ GET /api/node/status
 
 - **Description**
 
-  Integrative endpoint `/api/node/status` returns both ADAMANT blockchain network information and node information with a single request. Result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version), [`loader`](#get-loading-status), `consensusSchedule`, `milestoneSchedule`, and `wsClient` info.
+  Integrative endpoint `/api/node/status` returns ADAMANT blockchain network and node information with a single
+  request. The result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version),
+  [`loader`](#get-loading-status), `consensusSchedule`, `milestoneSchedule`, and `wsClient` information.
 
-  `wsClient` describes if node allows [socket connections](/api/websocket.html#enabling-websocket) and port to connect.
+  `wsClient` shows whether the node accepts [WebSocket connections](/api/websocket.md#enabling-websocket) and, when
+  enabled, which port clients should use.
 
-  `network.consensus` identifies the latest cumulative consensus upgrade active at `network.height`. It is `null`
-  before the first configured activation. An upgrade configured for height `H` is reported starting at block `H`.
+  `network.consensusCodeName` identifies the latest cumulative consensus upgrade active at `network.height`. It is
+  `null` before the first configured activation. An upgrade configured for height `H` is reported starting at block
+  `H`.
 
   `consensusSchedule.activationHeights` maps consensus codenames to their activation block heights. These are the
   node's effective runtime values after defaults, its selected configuration file, and startup overrides are merged.
@@ -684,7 +688,7 @@ GET /api/node/status
       "broadhash": "2d94f9070fe4ca236aaee9fd9a6863fd0b9291a80b96ac9e470408a852f0f3d8",
       "epoch": "2017-09-02T17:00:00.000Z",
       "height": 1034307,
-      "consensus": "fairSystem",
+      "consensusCodeName": "fairSystem",
       "fee": 50000000,
       "milestone": 0,
       "nethash": "38f153a81332dea86751451fd992df26a9249f0834f72f58f84ac31cceb70f43",

--- a/api-endpoints/blockchain.md
+++ b/api-endpoints/blockchain.md
@@ -598,6 +598,7 @@ GET /api/blocks/getStatus
   - [`broadhash`](#get-blockchain-broadhash)
   - [`epoch`](#get-blockchain-epoch)
   - [`height`](#get-blockchain-height)
+  - `consensus` — latest consensus upgrade active at `height`, or `null` before the first configured activation
   - [`fee`](#get-blockchain-fee)
   - [`milestone`](#get-blockchain-milestone)
   - [`nethash`](#get-blockchain-nethash)
@@ -621,6 +622,7 @@ GET /api/blocks/getStatus
     "broadhash": "4a28272c915f74d118120bb47db547a18a7512e1d48092c48be86939a6d45b89",
     "epoch": "2017-09-02T17:00:00.000Z",
     "height": 10145334,
+    "consensus": "fairSystem",
     "fee": 50000000,
     "milestone": 1,
     "nethash": "bd330166898377fb28743ceef5e43a5d9d0a3efd9b3451fb7bc53530bb0a6d64",
@@ -637,9 +639,24 @@ GET /api/node/status
 
 - **Description**
 
-  Integrative endpoint `/api/node/status` returns both ADAMANT blockchain network information and Node information with a single request. Result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version), [`loader`](#get-loading-status) and `wsClient` info.
+  Integrative endpoint `/api/node/status` returns both ADAMANT blockchain network information and node information with a single request. Result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version), [`loader`](#get-loading-status), `consensusSchedule`, `milestoneSchedule`, and `wsClient` info.
 
   `wsClient` describes if node allows [socket connections](/api/websocket.html#enabling-websocket) and port to connect.
+
+  `network.consensus` identifies the latest cumulative consensus upgrade active at `network.height`. It is `null`
+  before the first configured activation. An upgrade configured for height `H` is reported starting at block `H`.
+
+  `consensusSchedule.activationHeights` maps consensus codenames to their activation block heights. These are the
+  node's effective runtime values after defaults, its selected configuration file, and startup overrides are merged.
+  Activation heights are network- and configuration-specific; clients must not assume the example values below.
+
+  `milestoneSchedule` describes the block reward schedule:
+
+  - `offset` — first block height that receives a block reward
+  - `distance` — number of block heights between reward milestones
+  - `milestones` — reward at each milestone as integer base units, where `1 ADM = 100000000`
+
+  These fields are additive. Clients that support older node versions should handle their absence.
 
 - **Example**
 
@@ -667,11 +684,33 @@ GET /api/node/status
       "broadhash": "2d94f9070fe4ca236aaee9fd9a6863fd0b9291a80b96ac9e470408a852f0f3d8",
       "epoch": "2017-09-02T17:00:00.000Z",
       "height": 1034307,
+      "consensus": "fairSystem",
       "fee": 50000000,
       "milestone": 0,
       "nethash": "38f153a81332dea86751451fd992df26a9249f0834f72f58f84ac31cceb70f43",
       "reward": 0,
       "supply": 9800000000000000
+    },
+    "consensusSchedule": {
+      "activationHeights": {
+        "fairSystem": 809,
+        "spaceship": 100000000
+      }
+    },
+    "milestoneSchedule": {
+      "offset": 2000000,
+      "distance": 6300000,
+      "milestones": [
+        50000000,
+        45000000,
+        40000000,
+        35000000,
+        30000000,
+        25000000,
+        20000000,
+        15000000,
+        10000000
+      ]
     },
     "version": {
       "build": "",

--- a/api-endpoints/delegates.md
+++ b/api-endpoints/delegates.md
@@ -30,6 +30,8 @@ GET /api/delegates
   - `producedblocks` — count of produced blocks
   - `missedblocks` — count of missed blocks
   - `productivity` — productivity/uptime of delegate. Will be `0` if the delegate is not active.
+  - `forged` — lifetime sum of block fees and rewards as a base-10 integer string in base units
+    (`1 ADM = 100000000`)
 
 - **Example**
 
@@ -57,7 +59,8 @@ GET /api/delegates
         "rate": 102,
         "rank": 102,
         "approval": 0.37,
-        "productivity": 0
+        "productivity": 0,
+        "forged": "182540750000000"
       },
       {
         "username": "bcboilermaker",
@@ -70,7 +73,8 @@ GET /api/delegates
         "rate": 103,
         "rank": 103,
         "approval": 0.35,
-        "productivity": 0
+        "productivity": 0,
+        "forged": "275118500000000"
       }
     ],
     "totalCount": 254
@@ -118,7 +122,8 @@ GET /api/delegates/get
       "rate": 52,
       "rank": 52,
       "approval": 0.48,
-      "productivity": 98.55
+      "productivity": 98.55,
+      "forged": "204763350000000"
     }
   }
   ```
@@ -133,7 +138,8 @@ GET /api/delegates/search?q={searchCriteria}
 
   Search delegates by `username` (or part of it) using endpoint `/api/delegates/search` with parameter `q` for nickname.
 
-  Result includes [list of delegates](#get-delegates) with additional fields:
+  Result includes the core [delegate fields](#get-delegates), except the lifetime `forged` amount, with additional
+  fields:
 
   - `voters_cnt` — count of accounts who vote for the delegate
   - `register_timestamp` — epoch timestamp of when the delegate registered

--- a/api-endpoints/delegates.md
+++ b/api-endpoints/delegates.md
@@ -272,16 +272,21 @@ GET /api/delegates/getNextForgers
 
 - **Description**
 
-  Endpoint `/api/delegates/getNextForgers` returns the list of next forgers:
+  Endpoint `/api/delegates/getNextForgers` returns a snapshot of the next forgers for the current chain tip.
+  The `delegates` array is ordered by upcoming slots using the delegate schedule for `currentBlock + 1`, including
+  when `currentBlock` closes a round. All entries in one response use this next-block schedule because the block
+  height advances only after a block is accepted. Request a new snapshot after the node accepts another block.
+
+  The response includes:
 
   - `currentBlock` — current [blockchain height](/api-endpoints/blockchain.md#get-blockchain-height)
   - `currentBlockSlot` — current block slot number
   - `currentSlot` — current slot number
-  - `delegates` — array of next forgers' public keys
+  - `delegates` — array of next forgers' public keys ordered by upcoming slots
 
   Available parameters:
 
-  - `limit` — count to retrieve
+  - `limit` — number of public keys to retrieve, from 1 to 101. Default is 10.
 
 - **Example**
 


### PR DESCRIPTION
## Description

Document the additive Node API fields introduced for consensus/reward schedule discovery, lifetime delegate forged totals, and the corrected next-forger schedule semantics.

- describe `consensusCodeName` in `GET /api/blocks/getStatus`;
- describe `network.consensusCodeName`, `consensusSchedule`, and `milestoneSchedule` in `GET /api/node/status`;
- clarify activation boundaries, effective runtime values, base-unit rewards, and compatibility with older nodes;
- add the `forged` decimal string to delegate list and single-delegate examples;
- clarify that delegate search keeps its existing response shape without `forged`;
- document that `GET /api/delegates/getNextForgers` is a next-block snapshot, including round boundaries, refresh behavior, and `limit` constraints.

## Related issue

Closes #36

- Adamant-im/adamant#234
- Adamant-im/adamant#265
- Adamant-im/adamant#267
- Adamant-im/adamant-schema#50

## How to test

```sh
npm run docs:build
```

The affected Blockchain and Delegates pages were also inspected in the local VitePress preview.

Review follow-up also improves the node status prose and uses the canonical internal WebSocket documentation link.

## Checklist

- [x] Content matches the current Node implementation.
- [x] Field types, units, and boundary semantics are documented.
- [x] Existing API fields and examples remain intact.
- [x] The production documentation build succeeds.
