### PR TITLE
Docs: Release docs for node v0.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ node_modules
 
 # ai
 .ai-ignored/
+.ai-tasks/
+.claude/
+.cursor/
+

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -187,7 +187,7 @@ GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
   Request:
 
   ```sh
-  GET https://endless.adamant.im/api/accounts/top?limit=2&offset=0&isDelegate=1
+  GET https://endless.adamant.im/api/accounts/top?limit=1&offset=0&isDelegate=1
   ```
 
   Response:

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -169,8 +169,10 @@ GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
 
 - **Description**
 
-  Returns accounts sorted by confirmed `balance` in descending order. Accounts with the same balance are sorted by
-  `address` in ascending order, so pagination stays stable between requests.
+  Returns non-zero-balance accounts sorted by confirmed `balance` in descending order. Accounts with the same balance
+  are sorted by `address` in ascending order, so pagination stays stable between requests.
+
+  The `count` field reports how many non-zero-balance accounts match the current filter before pagination is applied.
 
   This endpoint is available on every node that supports it; it does not require a node-side feature flag.
 

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -206,7 +206,7 @@ GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
       }
     ],
     "count": 254,
-    "limit": 2,
+    "limit": 1,
     "offset": 0
   }
   ```

--- a/api-endpoints/accounts.md
+++ b/api-endpoints/accounts.md
@@ -161,6 +161,56 @@ GET /api/accounts/getPublicKey?address={ADAMANT address}
   }
   ```
 
+## Get Top Accounts
+
+```sh
+GET /api/accounts/top?limit={limit}&offset={offset}&isDelegate={isDelegate}
+```
+
+- **Description**
+
+  Returns accounts sorted by confirmed `balance` in descending order. Accounts with the same balance are sorted by
+  `address` in ascending order, so pagination stays stable between requests.
+
+  This endpoint is available on every node that supports it; it does not require a node-side feature flag.
+
+- **Parameters**
+
+  | Parameter    | Type    | Required | Description                                                                                                                       |
+  | ------------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+  | `limit`      | integer | No       | Number of accounts to return. Default is `100`, maximum is `100`. Use `0` to return only `count`, `limit`, and `offset` metadata. |
+  | `offset`     | integer | No       | Number of sorted accounts to skip. Default is `0`.                                                                                |
+  | `isDelegate` | integer | No       | Filter by delegate status. Use `1` for delegate accounts and `0` for non-delegate accounts.                                       |
+
+- **Example**
+
+  Request:
+
+  ```sh
+  GET https://endless.adamant.im/api/accounts/top?limit=2&offset=0&isDelegate=1
+  ```
+
+  Response:
+
+  ```jsonc
+  {
+    "success": true,
+    "nodeTimestamp": 63205623,
+    "accounts": [
+      {
+        "address": "U777355171330060015",
+        "balance": "4509718944753",
+        "publicKey": "a9407418dafb3c8aeee28f3263fd55bae0f528a5697a9df0e77e6568b19dfe34",
+        "username": "adamant_delegate",
+        "isDelegate": 1
+      }
+    ],
+    "count": 254,
+    "limit": 2,
+    "offset": 0
+  }
+  ```
+
 ## Create New Account
 
 ```sh

--- a/api-endpoints/blockchain.md
+++ b/api-endpoints/blockchain.md
@@ -598,7 +598,8 @@ GET /api/blocks/getStatus
   - [`broadhash`](#get-blockchain-broadhash)
   - [`epoch`](#get-blockchain-epoch)
   - [`height`](#get-blockchain-height)
-  - `consensusCodeName` — latest consensus upgrade active at `height`, or `null` before the first configured activation
+  - `consensusCodeName` — latest consensus upgrade active at `height`, or `null` before the first configured
+    activation
   - [`fee`](#get-blockchain-fee)
   - [`milestone`](#get-blockchain-milestone)
   - [`nethash`](#get-blockchain-nethash)

--- a/api-endpoints/blockchain.md
+++ b/api-endpoints/blockchain.md
@@ -598,7 +598,7 @@ GET /api/blocks/getStatus
   - [`broadhash`](#get-blockchain-broadhash)
   - [`epoch`](#get-blockchain-epoch)
   - [`height`](#get-blockchain-height)
-  - `consensus` — latest consensus upgrade active at `height`, or `null` before the first configured activation
+  - `consensusCodeName` — latest consensus upgrade active at `height`, or `null` before the first configured activation
   - [`fee`](#get-blockchain-fee)
   - [`milestone`](#get-blockchain-milestone)
   - [`nethash`](#get-blockchain-nethash)
@@ -622,7 +622,7 @@ GET /api/blocks/getStatus
     "broadhash": "4a28272c915f74d118120bb47db547a18a7512e1d48092c48be86939a6d45b89",
     "epoch": "2017-09-02T17:00:00.000Z",
     "height": 10145334,
-    "consensus": "fairSystem",
+    "consensusCodeName": "fairSystem",
     "fee": 50000000,
     "milestone": 1,
     "nethash": "bd330166898377fb28743ceef5e43a5d9d0a3efd9b3451fb7bc53530bb0a6d64",
@@ -639,12 +639,16 @@ GET /api/node/status
 
 - **Description**
 
-  Integrative endpoint `/api/node/status` returns both ADAMANT blockchain network information and node information with a single request. Result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version), [`loader`](#get-loading-status), `consensusSchedule`, `milestoneSchedule`, and `wsClient` info.
+  Integrative endpoint `/api/node/status` returns ADAMANT blockchain network and node information with a single
+  request. The result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version),
+  [`loader`](#get-loading-status), `consensusSchedule`, `milestoneSchedule`, and `wsClient` information.
 
-  `wsClient` describes if node allows [socket connections](/api/websocket.html#enabling-websocket) and port to connect.
+  `wsClient` shows whether the node accepts [WebSocket connections](/api/websocket.md#enabling-websocket) and, when
+  enabled, which port clients should use.
 
-  `network.consensus` identifies the latest cumulative consensus upgrade active at `network.height`. It is `null`
-  before the first configured activation. An upgrade configured for height `H` is reported starting at block `H`.
+  `network.consensusCodeName` identifies the latest cumulative consensus upgrade active at `network.height`. It is
+  `null` before the first configured activation. An upgrade configured for height `H` is reported starting at block
+  `H`.
 
   `consensusSchedule.activationHeights` maps consensus codenames to their activation block heights. These are the
   node's effective runtime values after defaults, its selected configuration file, and startup overrides are merged.
@@ -684,7 +688,7 @@ GET /api/node/status
       "broadhash": "2d94f9070fe4ca236aaee9fd9a6863fd0b9291a80b96ac9e470408a852f0f3d8",
       "epoch": "2017-09-02T17:00:00.000Z",
       "height": 1034307,
-      "consensus": "fairSystem",
+      "consensusCodeName": "fairSystem",
       "fee": 50000000,
       "milestone": 0,
       "nethash": "38f153a81332dea86751451fd992df26a9249f0834f72f58f84ac31cceb70f43",

--- a/api-endpoints/blockchain.md
+++ b/api-endpoints/blockchain.md
@@ -598,6 +598,7 @@ GET /api/blocks/getStatus
   - [`broadhash`](#get-blockchain-broadhash)
   - [`epoch`](#get-blockchain-epoch)
   - [`height`](#get-blockchain-height)
+  - `consensus` — latest consensus upgrade active at `height`, or `null` before the first configured activation
   - [`fee`](#get-blockchain-fee)
   - [`milestone`](#get-blockchain-milestone)
   - [`nethash`](#get-blockchain-nethash)
@@ -621,6 +622,7 @@ GET /api/blocks/getStatus
     "broadhash": "4a28272c915f74d118120bb47db547a18a7512e1d48092c48be86939a6d45b89",
     "epoch": "2017-09-02T17:00:00.000Z",
     "height": 10145334,
+    "consensus": "fairSystem",
     "fee": 50000000,
     "milestone": 1,
     "nethash": "bd330166898377fb28743ceef5e43a5d9d0a3efd9b3451fb7bc53530bb0a6d64",
@@ -637,9 +639,24 @@ GET /api/node/status
 
 - **Description**
 
-  Integrative endpoint `/api/node/status` returns both ADAMANT blockchain network information and Node information with a single request. Result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version), [`loader`](#get-loading-status) and `wsClient` info.
+  Integrative endpoint `/api/node/status` returns both ADAMANT blockchain network information and node information with a single request. Result includes [`network`](#get-adamant-blockchain-network-info), [`version`](#get-node-version), [`loader`](#get-loading-status), `consensusSchedule`, `milestoneSchedule`, and `wsClient` info.
 
   `wsClient` describes if node allows [socket connections](/api/websocket.html#enabling-websocket) and port to connect.
+
+  `network.consensus` identifies the latest cumulative consensus upgrade active at `network.height`. It is `null`
+  before the first configured activation. An upgrade configured for height `H` is reported starting at block `H`.
+
+  `consensusSchedule.activationHeights` maps consensus codenames to their activation block heights. These are the
+  node's effective runtime values after defaults, its selected configuration file, and startup overrides are merged.
+  Activation heights are network- and configuration-specific; clients must not assume the example values below.
+
+  `milestoneSchedule` describes the block reward schedule:
+
+  - `offset` — first block height that receives a block reward
+  - `distance` — number of block heights between reward milestones
+  - `milestones` — reward at each milestone as integer base units, where `1 ADM = 100000000`
+
+  These fields are additive. Clients that support older node versions should handle their absence.
 
 - **Example**
 
@@ -667,11 +684,33 @@ GET /api/node/status
       "broadhash": "2d94f9070fe4ca236aaee9fd9a6863fd0b9291a80b96ac9e470408a852f0f3d8",
       "epoch": "2017-09-02T17:00:00.000Z",
       "height": 1034307,
+      "consensus": "fairSystem",
       "fee": 50000000,
       "milestone": 0,
       "nethash": "38f153a81332dea86751451fd992df26a9249f0834f72f58f84ac31cceb70f43",
       "reward": 0,
       "supply": 9800000000000000
+    },
+    "consensusSchedule": {
+      "activationHeights": {
+        "fairSystem": 809,
+        "spaceship": 100000000
+      }
+    },
+    "milestoneSchedule": {
+      "offset": 2000000,
+      "distance": 6300000,
+      "milestones": [
+        50000000,
+        45000000,
+        40000000,
+        35000000,
+        30000000,
+        25000000,
+        20000000,
+        15000000,
+        10000000
+      ]
     },
     "version": {
       "build": "",

--- a/api-endpoints/blocks.md
+++ b/api-endpoints/blocks.md
@@ -74,7 +74,9 @@ GET /api/blocks
 
 - **Description**
 
-  Get a list of blocks from the ADAMANT blockchain using the `/api/blocks/` endpoint. Returns an array of [blocks](#get-block-by-id) from newest to oldest.
+  Get a list of blocks from the ADAMANT blockchain using the `/api/blocks/` endpoint. Returns an
+  array of [blocks](#get-block-by-id) ordered by `orderBy` (default: `height:desc`, from newest to
+  oldest).
 
   Available parameters:
 
@@ -87,9 +89,9 @@ GET /api/blocks
   | `numberOfTransactions` | Exact non-negative number of transactions in the block |
   | `previousBlock` | ID of the preceding block |
   | `height` | Exact positive block height |
-  | `totalAmount` | Exact non-negative total amount transferred by the block's transactions, in 1/10^8 ADM |
-  | `totalFee` | Exact non-negative total transaction fee, in 1/10^8 ADM |
-  | `reward` | Exact non-negative forging reward, in 1/10^8 ADM |
+  | `totalAmount` | Exact non-negative integer amount of 1/10^8 ADM tokens transferred within all transactions in the block |
+  | `totalFee` | Exact non-negative integer amount of 1/10^8 ADM tokens paid as transaction fees in the block |
+  | `reward` | Exact non-negative integer amount of 1/10^8 ADM tokens created as the forging reward |
 
   `orderBy` accepts `asc` or `desc` for the following fields: `id`, `timestamp`, `height`,
   `previousBlock`, `totalAmount`, `totalFee`, `reward`, `numberOfTransactions`, and

--- a/api-endpoints/blocks.md
+++ b/api-endpoints/blocks.md
@@ -49,7 +49,6 @@ GET /api/blocks/get?id={block's id}
       "id": "11114690216332606721",
       "version": 0,
       "timestamp": 61741820,
-      "timestampMs": null,
       "height": 10873829,
       "previousBlock": "11483763337863654141",
       "numberOfTransactions": 1,
@@ -79,10 +78,22 @@ GET /api/blocks
 
   Available parameters:
 
-  - `limit` — number of blocks to retrieve (default: 100)
-  - `offset` — height offset value for results (default: 0)
-  - `generatorPublicKey` — public key of the delegate who generated the block
-  - `height` — specific block height
+  | Parameter | Description |
+  | --- | --- |
+  | `limit` | Number of blocks to retrieve, from 1 to 100 (default: 100) |
+  | `offset` | Number of rows to skip after applying the requested order, starting from 0 (default: 0) |
+  | `orderBy` | Sort expression in `field:direction` form (default: `height:desc`) |
+  | `generatorPublicKey` | 64-character hexadecimal public key of the delegate who generated the block |
+  | `numberOfTransactions` | Exact non-negative number of transactions in the block |
+  | `previousBlock` | ID of the preceding block |
+  | `height` | Exact positive block height |
+  | `totalAmount` | Exact non-negative total amount transferred by the block's transactions, in 1/10^8 ADM |
+  | `totalFee` | Exact non-negative total transaction fee, in 1/10^8 ADM |
+  | `reward` | Exact non-negative forging reward, in 1/10^8 ADM |
+
+  `orderBy` accepts `asc` or `desc` for the following fields: `id`, `timestamp`, `height`,
+  `previousBlock`, `totalAmount`, `totalFee`, `reward`, `numberOfTransactions`, and
+  `generatorPublicKey`.
 
 - **Example**
 
@@ -103,7 +114,6 @@ GET /api/blocks
         "id": "15416108601994762552",
         "version": 0,
         "timestamp": 58045350,
-        "timestampMs": null,
         "height": 10144920,
         "previousBlock": "16611488400968379374",
         "numberOfTransactions": 0,
@@ -122,7 +132,6 @@ GET /api/blocks
         "id": "16611488400968379374",
         "version": 0,
         "timestamp": 58045345,
-        "timestampMs": null,
         "height": 10144919,
         "previousBlock": "17869865393675106520",
         "numberOfTransactions": 0,

--- a/api-endpoints/delegates.md
+++ b/api-endpoints/delegates.md
@@ -30,6 +30,8 @@ GET /api/delegates
   - `producedblocks` — count of produced blocks
   - `missedblocks` — count of missed blocks
   - `productivity` — productivity/uptime of delegate. Will be `0` if the delegate is not active.
+  - `forged` — lifetime sum of block fees and rewards as a base-10 integer string in base units
+    (`1 ADM = 100000000`)
 
 - **Example**
 
@@ -57,7 +59,8 @@ GET /api/delegates
         "rate": 102,
         "rank": 102,
         "approval": 0.37,
-        "productivity": 0
+        "productivity": 0,
+        "forged": "182540750000000"
       },
       {
         "username": "bcboilermaker",
@@ -70,7 +73,8 @@ GET /api/delegates
         "rate": 103,
         "rank": 103,
         "approval": 0.35,
-        "productivity": 0
+        "productivity": 0,
+        "forged": "275118500000000"
       }
     ],
     "totalCount": 254
@@ -118,7 +122,8 @@ GET /api/delegates/get
       "rate": 52,
       "rank": 52,
       "approval": 0.48,
-      "productivity": 98.55
+      "productivity": 98.55,
+      "forged": "204763350000000"
     }
   }
   ```
@@ -133,7 +138,8 @@ GET /api/delegates/search?q={searchCriteria}
 
   Search delegates by `username` (or part of it) using endpoint `/api/delegates/search` with parameter `q` for nickname.
 
-  Result includes [list of delegates](#get-delegates) with additional fields:
+  Result includes the core [delegate fields](#get-delegates), except the lifetime `forged` amount, with additional
+  fields:
 
   - `voters_cnt` — count of accounts who vote for the delegate
   - `register_timestamp` — epoch timestamp of when the delegate registered

--- a/api-endpoints/delegates.md
+++ b/api-endpoints/delegates.md
@@ -272,16 +272,21 @@ GET /api/delegates/getNextForgers
 
 - **Description**
 
-  Endpoint `/api/delegates/getNextForgers` returns the list of next forgers:
+  Endpoint `/api/delegates/getNextForgers` returns a snapshot of the next forgers for the current chain tip.
+  The `delegates` array is ordered by upcoming slots using the delegate schedule for `currentBlock + 1`, including
+  when `currentBlock` closes a round. All entries in one response use this next-block schedule because the block
+  height advances only after a block is accepted. Request a new snapshot after the node accepts another block.
+
+  The response includes:
 
   - `currentBlock` — current [blockchain height](/api-endpoints/blockchain.md#get-blockchain-height)
   - `currentBlockSlot` — current block slot number
   - `currentSlot` — current slot number
-  - `delegates` — array of next forgers' public keys
+  - `delegates` — array of next forgers' public keys ordered by upcoming slots
 
   Available parameters:
 
-  - `limit` — count to retrieve
+  - `limit` — number of public keys to retrieve, from 1 to 101. Default is 10.
 
 - **Example**
 

--- a/api/transactions-query-language.md
+++ b/api/transactions-query-language.md
@@ -302,7 +302,7 @@ You can filter by single parameter, or by multiple parameters. Default condition
 
 Options always joined with `and` condition.
 
-For confirmed transactions, the node composes supported filters into one flat SQL `WHERE` expression:
+For confirmed transactions, you can prefix filters with `and:` or `or:` to control how they are joined, and the node composes the resulting filter chain into one flat SQL `WHERE` expression:
 
 1. Filters are appended in the same order in which they appear in the query string.
 2. The first filter starts the expression, so its `and:` or `or:` prefix does not change the result.

--- a/api/transactions-query-language.md
+++ b/api/transactions-query-language.md
@@ -302,6 +302,36 @@ You can filter by single parameter, or by multiple parameters. Default condition
 
 Options always joined with `and` condition.
 
+For confirmed transactions, the node composes supported filters into one flat SQL `WHERE` expression:
+
+1. Filters are appended in the same order in which they appear in the query string.
+2. The first filter starts the expression, so its `and:` or `or:` prefix does not change the result.
+3. The node does not add grouping parentheses around mixed `and:`/`or:` conditions.
+4. Standard SQL precedence applies inside the flat expression: `AND` is evaluated before `OR`.
+
+This makes parameter order significant. The same filters can return different transactions when they are reordered:
+
+| Query string | Effective condition |
+| --- | --- |
+| `and:inId=U100739400829575109&and:minAmount=1&or:types=0,1,2,3,4,5,6,7` | `(inId AND minAmount) OR types` |
+| `or:types=0,1,2,3,4,5,6,7&and:inId=U100739400829575109&and:minAmount=1` | `types AND inId AND minAmount` |
+| `or:minAmount=1&and:types=0,1,2,3,4,5,6,7` | `minAmount AND types` |
+| `and:types=0,1,2,3,4,5,6,7&or:minAmount=1` | `types OR minAmount` |
+
+Grouping is not supported. You can express `(A AND B) OR C` by placing the `or:` condition after the
+`and:` conditions, but you cannot express `A AND (B OR C)` in one request.
+
+Be careful when adding `or:` filters to an address filter. For example, this request returns transactions for
+`U100739400829575109` with a positive amount and also every transaction of types `0` through `7`, including
+transactions unrelated to that address:
+
+```url
+https://endless.adamant.im/api/transactions?and:inId=U100739400829575109&and:minAmount=1&or:types=0,1,2,3,4,5,6,7
+```
+
+If the address must apply to all returned transactions, keep every additional filter joined with `and:` or make
+separate requests for logical shapes that need grouping.
+
 - **Examples**
 
   Get transactions where height greater than `1336065` **or** `blockId = 7917597195203393333`:

--- a/api/websocket.md
+++ b/api/websocket.md
@@ -1,24 +1,28 @@
 # WebSocket
 
-ADAMANT doesn't require WebSocket connection, but it helps achieve real-time message delivery, reducing delays compared to polling and providing a faster, more efficient connection between the client and the node.
+The client WebSocket API delivers live transaction, account balance, and block events without repeated REST polling.
+ADAMANT nodes use [Socket.IO](https://socket.io/), so use a
+[Socket.IO client](https://socket.io/docs/v4/client-api/) instead of a bare WebSocket client.
 
-The nodes use [Socket.IO](https://socket.io/) under the hood for communication between clients and nodes, so it's recommended to use a [Socket.IO client](https://socket.io/docs/v4/client-api/) for full compatibility and reliable messaging.
-
-The following examples use native socket.io, but it's still recommended using the [adamant-api-jsclient](https://github.com/adamant-im/adamant-api-jsclient) official library to handle transactions.
+The examples below use `socket.io-client`. Applications can also use
+[adamant-api-jsclient](https://github.com/Adamant-im/adamant-api-jsclient) for higher-level ADAMANT API access.
 
 ## WebSocket vs REST API
 
-WebSocket is a fast and efficient way to receive new transactions, but it should not be the only data source.
+WebSocket events are live notifications, not a durable event log:
 
-- WebSocket connections can drop temporarily, causing missed transactions.
-- Nodes only retain transactions for 60 seconds in the WebSocket pool.
-- Periodic REST API requests ensure the client has accurate transaction history.
+- Connections can drop, so an application can miss events.
+- Subscriptions belong to one socket and must be sent again after every connection or reconnection.
+- The node suppresses duplicate transaction and block IDs for 60 seconds. This is not a replay buffer.
+- Balance subscriptions do not send an initial value.
 
-To maintain reliability, use WebSocket for real-time updates and REST API to periodically fetch missed transactions.
+Read initial state from REST, use WebSocket events for low-latency updates, and reconcile important state through REST after
+reconnecting. For example, use `/api/accounts/getBalance` for balances and `/api/blocks` for blocks.
 
 ## Enabling WebSocket
 
-To enable WebSocket on a node, enable it in the [configuration file](/own-node/configuration.md#websocket-client-configuration):
+Enable the client WebSocket server in the node
+[configuration file](/own-node/configuration.md#websocket-client-configuration):
 
 ```json
 {
@@ -29,13 +33,9 @@ To enable WebSocket on a node, enable it in the [configuration file](/own-node/c
 }
 ```
 
-To check if the node offers WebSocket connections, request its status:
+To discover whether a node offers client WebSocket connections, request `/api/node/status` over its REST API.
 
-```sh
-https://localhost:36668/api/node/status
-```
-
-Example response:
+Example response fragment:
 
 ```json
 {
@@ -43,7 +43,6 @@ Example response:
   "nodeTimestamp": 226901657,
   "nodeTimestampMs": 226901657123,
   "unixTimestampMs": 1731273257123,
-  // ...
   "wsClient": {
     "enabled": true,
     "port": 36668
@@ -51,44 +50,24 @@ Example response:
 }
 ```
 
-## Listening to transactions
+## Connecting and restoring subscriptions
 
-ADAMANT nodes send transactions over WebSocket. This includes both confirmed and unconfirmed transactions.
-
-After the `spaceship` consensus activation, transaction payloads can include `timestampMs` when the transaction was created with millisecond precision and the node stored it. This value is measured in milliseconds since the ADAMANT epoch. Clients should prefer it for message ordering and fall back to `timestamp * 1000` when it is missing or `null`.
-
-### Understanding unconfirmed transactions
-
-New transactions do not appear on the blockchain immediately. When a transaction is first created, it is considered **unconfirmed** and does not have a `block_timestamp`.
-
-Most transactions received via WebSocket are unconfirmed since they have just appeared in the ADAMANT network. Until they are included in a block, they remain at **risk of being rejected** by the network and called "unconfirmed".
-
-::: danger
-
-Any logic involving transfer transactions (`amount` > 0) should verify the confirmation status before processing them as final.
-
-:::
-
-### Subscribing to transactions
-
-Clients can subscribe to the `newTrans` event to receive transaction updates from a node.
-
-Example:
+Register subscriptions inside the `connect` handler. Socket.IO calls it again after a successful reconnection, so the new
+server-side socket receives the same subscriptions.
 
 ```js
 import { io } from 'socket.io-client';
 
 const connection = io('https://endless.adamant.im/', {
-  reconnection: false,
+  reconnection: true,
   timeout: 5000,
 });
 
 connection.on('connect', () => {
-  console.log('Connected to ADAMANT node.');
-});
-
-connection.on('newTrans', (transaction) => {
-  console.log('New transaction received:', transaction);
+  connection.emit('address', 'U1234567890123456');
+  connection.emit('types', [0, 8]);
+  connection.emit('balances', ['balance', 'unconfirmedBalance']);
+  connection.emit('blocks', true);
 });
 
 connection.on('disconnect', (reason) => {
@@ -100,57 +79,162 @@ connection.on('connect_error', (error) => {
 });
 ```
 
-### Filtering transactions
+## Subscription events
 
-By default, **all** transactions are received. Clients should filter transactions based on their needs.
+Clients send the following Socket.IO events:
 
-#### Filtering by Address
+| Event | Payload | Effect |
+|---|---|---|
+| `address` | Address string or array | Filters `newTrans` and selects addresses used by balance subscriptions |
+| `types` | Transaction type number or array | Filters `newTrans` by transaction type |
+| `assetChatTypes` | Chat asset type number or array | Filters chat `newTrans` events by `asset.chat.type` |
+| `balances` | `balance`, `unconfirmedBalance`, or an array of both | Enables requested `balances/change` fields |
+| `blocks` | Boolean | `true` enables and `false` disables `newBlock` events |
 
-To receive only transactions related to a specific ADM address, emit `address` event:
+Address, transaction type, chat type, and balance field subscriptions are additive for the lifetime of the socket. Unsupported
+values are ignored. The `blocks` payload must be a scalar boolean; arrays and other values are ignored.
+
+The API does not send subscription acknowledgements. A client should validate its own inputs and use REST reconciliation when
+delivery matters.
+
+## Listening to transactions
+
+The node emits `newTrans` when it applies a transaction to the unconfirmed pool. The payload is provisional and has
+`block_timestamp: null`; confirm inclusion through `newBlock` plus REST, or by querying the transaction later.
+
+After the `spaceship` consensus activation, the payload can include `timestampMs` when the transaction was created with
+millisecond precision. This value is measured from the ADAMANT epoch. Prefer it for ordering and fall back to
+`timestamp * 1000` when it is missing or `null`.
 
 ```js
-connection.on('connect', () => {
-  // Subscribe to transactions involving this ADM address
-  connection.emit('address', 'U1234567890123456');
+connection.on('newTrans', (transaction) => {
+  console.log('New unconfirmed transaction:', transaction);
 });
 ```
 
-You can also subscribe to **multiple** addresses by passing an array:
+### Understanding unconfirmed transactions
+
+New transactions do not appear on the blockchain immediately. Until a delegate includes a transaction in a valid block, it
+can expire, be rejected, or be removed during pool revalidation.
+
+::: danger
+
+Any logic involving transfer transactions (`amount` greater than `0`) should verify blockchain confirmation before treating
+the transfer as final.
+
+:::
+
+### Filtering transactions
+
+A socket receives no `newTrans` events until it sends at least one valid `address`, `types`, or `assetChatTypes` subscription.
+
+Filters combine as follows:
+
+- With only `address`, the socket receives every transaction involving any subscribed sender or recipient.
+- With only `types`, the socket receives those transaction types for all addresses.
+- With addresses and type filters, a transaction must match a subscribed address and a subscribed type.
+- `assetChatTypes` applies to chat transaction type `8` and can match alongside ordinary transaction type filters.
+
+#### Filtering by address
 
 ```js
 connection.on('connect', () => {
+  connection.emit('address', 'U1234567890123456');
+  // Or subscribe to multiple addresses:
   connection.emit('address', ['U1234567890123456', 'U6543210987654321']);
 });
 ```
 
-#### Filtering by Transaction Type
+Addresses are validated and normalized to uppercase by the node.
 
-To receive only specific types of transactions, emit the `types` event with an array of transaction types.
+#### Filtering by transaction type
 
 ```js
 connection.on('connect', () => {
-  // Subscribe to a single transaction type: "transfer" (0)
   connection.emit('types', 0);
-
-  // OR subscribe to multiple transaction types: "transfer" (0) and "chat message" (8)
+  // Or subscribe to transfer (0) and chat message (8) transactions:
   connection.emit('types', [0, 8]);
 });
 ```
 
-A full list of transaction types can be found in the [API Specification](/api-types/transaction-types.md) section of the documentation.
+See the full list of [transaction types](/api-types/transaction-types.md).
 
-#### Filtering by Message Type
-
-Chat messages in ADAMANT have different [message types](/api-types/message-types.md) under `asset.chat.type`. To filter messages by type, emit the `assetChatTypes` event:
+#### Filtering by message type
 
 ```js
 connection.on('connect', () => {
-  // Subscribe to a single chat message type
   connection.emit('assetChatTypes', 3);
-
-  // OR subscribe to multiple chat message types
+  // Or subscribe to multiple asset.chat.type values:
   connection.emit('assetChatTypes', [1, 2, 3]);
 });
 ```
 
-This will make you automatically subscribe to Message **transaction type** (type `8`) if you weren't subscribed to it.
+See the full list of [message types](/api-types/message-types.md).
+
+## Listening to balance changes
+
+Balance events require at least one subscribed `address` and an explicit `balances` subscription. The node reads the current
+account only when a matching field changed and at least one socket subscribed to that address and field.
+
+```js
+connection.on('connect', () => {
+  connection.emit('address', ['U1234567890123456', 'U6543210987654321']);
+  connection.emit('balances', ['balance', 'unconfirmedBalance']);
+});
+
+connection.on('balances/change', (account) => {
+  console.log('Balance changed:', account);
+});
+```
+
+Example payload when both requested fields changed:
+
+```json
+{
+  "address": "U1234567890123456",
+  "balance": "100000000",
+  "unconfirmedBalance": "99900000"
+}
+```
+
+The payload contains only subscribed fields that changed. Balance values are decimal strings in 1/10^8 ADM units, matching
+the REST account API and avoiding integer precision loss.
+
+`balance` is confirmed blockchain state. `unconfirmedBalance` includes the node's current unconfirmed pool and can change when
+a transaction is received, confirmed, expired, rolled back, or revalidated. During block application and rollback, the node
+coalesces internal pool rewinds and sends the final account state instead of transient intermediate values.
+
+## Listening to new blocks
+
+Enable block events with a scalar boolean:
+
+```js
+connection.on('connect', () => {
+  connection.emit('blocks', true);
+});
+
+connection.on('newBlock', (block) => {
+  console.log('Applied block:', block);
+});
+```
+
+Example payload:
+
+```json
+{
+  "id": "1739739671268673627",
+  "height": 53532078,
+  "timestamp": 278966175,
+  "generatorPublicKey": "24636735d64711f91f7680bb348662bc74f7b3446e66702369527e3882dd30d6",
+  "numberOfTransactions": 2,
+  "totalAmount": 10000000,
+  "totalFee": 100000,
+  "reward": 10000000
+}
+```
+
+The event contains a compact public block header without the transaction list, signature, or payload hash. It is emitted after
+the complete block application pipeline succeeds. Historical blocks replayed from the node's existing database are not emitted.
+Use the block ID or height with REST when full block or transaction data is required.
+
+Send `connection.emit('blocks', false)` to stop block events for the current socket.

--- a/api/websocket.md
+++ b/api/websocket.md
@@ -14,7 +14,8 @@ WebSocket events are live notifications, not a durable event log:
 - Connections can drop, so an application can miss events.
 - Subscriptions belong to one socket and must be sent again after every connection or reconnection.
 - The node suppresses duplicate transaction and block IDs for at least 60 seconds; periodic cleanup can extend the effective
-  window to approximately two minutes. This is not a replay buffer.
+  window to approximately two minutes. A block rolled back and re-applied within this window can therefore be suppressed.
+  This is not a replay buffer.
 - Balance subscriptions do not send an initial value.
 
 Read initial state from REST, use WebSocket events for low-latency updates, and reconcile important state through REST after
@@ -142,8 +143,8 @@ Filters combine as follows:
 ```js
 connection.on('connect', () => {
   connection.emit('address', 'U1234567890123456');
-  // Or subscribe to multiple addresses:
-  connection.emit('address', ['U1234567890123456', 'U6543210987654321']);
+  // To subscribe to multiple addresses instead, use:
+  // connection.emit('address', ['U1234567890123456', 'U6543210987654321']);
 });
 ```
 
@@ -154,8 +155,8 @@ Addresses are validated and normalized to uppercase by the node.
 ```js
 connection.on('connect', () => {
   connection.emit('types', 0);
-  // Or subscribe to transfer (0) and chat message (8) transactions:
-  connection.emit('types', [0, 8]);
+  // To subscribe to transfer (0) and chat message (8) transactions instead, use:
+  // connection.emit('types', [0, 8]);
 });
 ```
 
@@ -166,8 +167,8 @@ See the full list of [transaction types](/api-types/transaction-types.md).
 ```js
 connection.on('connect', () => {
   connection.emit('assetChatTypes', 3);
-  // Or subscribe to multiple asset.chat.type values:
-  connection.emit('assetChatTypes', [1, 2, 3]);
+  // To subscribe to multiple asset.chat.type values instead, use:
+  // connection.emit('assetChatTypes', [1, 2, 3]);
 });
 ```
 

--- a/api/websocket.md
+++ b/api/websocket.md
@@ -13,7 +13,8 @@ WebSocket events are live notifications, not a durable event log:
 
 - Connections can drop, so an application can miss events.
 - Subscriptions belong to one socket and must be sent again after every connection or reconnection.
-- The node suppresses duplicate transaction and block IDs for 60 seconds. This is not a replay buffer.
+- The node suppresses duplicate transaction and block IDs for at least 60 seconds; periodic cleanup can extend the effective
+  window to approximately two minutes. This is not a replay buffer.
 - Balance subscriptions do not send an initial value.
 
 Read initial state from REST, use WebSocket events for low-latency updates, and reconcile important state through REST after
@@ -132,6 +133,7 @@ Filters combine as follows:
 
 - With only `address`, the socket receives every transaction involving any subscribed sender or recipient.
 - With only `types`, the socket receives those transaction types for all addresses.
+- With only `assetChatTypes`, the socket receives matching type `8` chat transactions for all addresses.
 - With addresses and type filters, a transaction must match a subscribed address and a subscribed type.
 - `assetChatTypes` applies to chat transaction type `8` and can match alongside ordinary transaction type filters.
 
@@ -197,12 +199,14 @@ Example payload when both requested fields changed:
 }
 ```
 
-The payload contains only subscribed fields that changed. Balance values are decimal strings in 1/10^8 ADM units, matching
-the REST account API and avoiding integer precision loss.
+The payload contains only subscribed fields that changed. Balance values use the same numeric account values as the REST
+account API and are serialized as decimal strings in 1/10^8 ADM units.
 
 `balance` is confirmed blockchain state. `unconfirmedBalance` includes the node's current unconfirmed pool and can change when
 a transaction is received, confirmed, expired, rolled back, or revalidated. During block application and rollback, the node
 coalesces internal pool rewinds and sends the final account state instead of transient intermediate values.
+Rapid independent account updates can still produce closely spaced events whose asynchronous reads complete out of order.
+Treat each payload as a live hint and reconcile important state through REST instead of relying on event order.
 
 ## Listening to new blocks
 

--- a/own-node/configuration.md
+++ b/own-node/configuration.md
@@ -200,18 +200,6 @@ Possible log levels (from least to most verbose):
 
   Cache is disabled by default on mainnet and enabled on testnet. Enabling it can improve API response times for high-traffic public nodes.
 
-- **Top Accounts**
-
-  Enable the `/api/accounts/top` endpoint (returns accounts sorted by balance) with `topAccounts`:
-
-  ```json
-  {
-    "topAccounts": false
-  }
-  ```
-
-  This endpoint is disabled by default on mainnet. Enabling it on a high-traffic node may have a performance impact.
-
 ## Database Configuration
 
 - **Database Connection**

--- a/own-node/configuration.md
+++ b/own-node/configuration.md
@@ -428,12 +428,22 @@ These values match the mainnet network. **Do not change them for a mainnet node*
   ```json
   {
     "loading": {
-      "loadPerIteration": 5000
+      "loadPerIteration": 5000,
+      "memCheckpoints": {
+        "enabled": true
+      }
     }
   }
   ```
 
   - `loadPerIteration`: Max blocks to verify per iteration (recommended: `5000`).
+  - `memCheckpoints.enabled`: Enable persisted checkpoints of derived `mem_*` tables for crash recovery (default: `true`). When startup detects inconsistent memory mirrors, the node attempts to restore the latest verified checkpoint and replay only blocks after the checkpoint height. If verification or replay fails, behavior falls back to the existing full memory-table rebuild from genesis.
+
+    Checkpoints are created after fully persisted blocks at completed round boundaries. During catch-up sync, creation is throttled to every 100th round. The node keeps three rotating checkpoint slots in the database (`mem_ckpt_0..2_*` plus `mem_state_checkpoint_meta`).
+
+    Checkpoints are a local recovery cache only. They do not replace graceful shutdown, trusted database snapshots, or blocks as the source of truth. Disabling checkpoints does not prevent recovery, but forces a full rebuild from genesis whenever `mem_*` validation fails.
+
+    See [Installation — Mem-table checkpoint recovery](./installation.md#mem-table-checkpoint-recovery) for operator guidance and log examples.
 
 ## SSL Configuration
 

--- a/own-node/installation.md
+++ b/own-node/installation.md
@@ -196,12 +196,41 @@ Alternatively, you can use pm2's built-in startup functionality: `pm2 save` — 
 ::: warning Critical Shutdown Notice
 Always stop the node gracefully. When running it in the foreground, press `Ctrl+C` and wait for cleanup to finish. Do not use `kill -9` or any other forced termination unless the process is already unrecoverably stuck.
 
-The node stores derived consensus state in memory tables (`mem_accounts`, `mem_round`). A forced kill can leave these inconsistent with the persisted blockchain, forcing a full rebuild from genesis on the next startup.
+After `Ctrl+C` / `SIGINT` / `SIGTERM`, shutdown is not always immediate. The node may log messages such as `Waiting for loader to finish active sync/rebuild…` or `Waiting for block processing to finish…` while it drains in-flight work safely. Wait until cleanup completes (for example `Cleaned up successfully`) before restarting, closing the terminal, or killing the process. Restarting too early can leave derived `mem_*` tables inconsistent and force a long rebuild on the next startup.
+
+The node stores derived consensus state in memory tables (`mem_accounts`, `mem_round`, and related mirrors). A forced kill can leave these inconsistent with the persisted blockchain. On the next startup this can appear as:
+
+```text
+[WRN] loader Detected unapplied rounds in mem_round
+[WRN] loader Recreating memory tables…
+[inf] loader Rebuilding blockchain, current block height: 1…
+```
+
+Do not repair `mem_*` tables with manual SQL edits. The reliable recovery options are restoring a trusted database snapshot or letting the node rebuild/replay derived state from the blockchain.
+:::
+
+### Mem-table checkpoint recovery
+
+When enabled (default), the node persists rotating checkpoints of derived `mem_*` tables at completed round boundaries. If startup detects inconsistent memory mirrors, the loader first attempts to restore the latest verified checkpoint and replay only blocks after the checkpoint height:
+
+```text
+[inf] loader Recovering from mem-table checkpoint at height 1234567…
+[inf] loader Rebuilding blockchain, current block height: 1234568…
+```
+
+Checkpoints are a local recovery cache only. Blocks and deterministic replay remain the source of truth. If checkpoint verification or replay fails, the node falls back to a full memory-table rebuild from genesis. You can disable this behavior with [`loading.memCheckpoints.enabled`](./configuration.md#loading-configuration).
+
+During catch-up sync, checkpoint creation is throttled (every 100th round) so sync throughput is not reduced by frequent `mem_*` copies. Under normal operation, a checkpoint is written after each completed round.
+
+::: info Storage impact
+Checkpoints use three rotating database slots plus metadata. On current mainnet, expect roughly 48 MB per slot and under 150 MB total for all retained slots. Budget extra free disk space for growth and rotation overhead.
 :::
 
 ### Recovering an ADAMANT node
 
 It may happen that your ADM node lost the current blockchain height and restarted from the beginning. The most common reasons are a hardware error or lack of disk space. Although validating blocks from height 0 is a valid option, catching up with the current height may take several days.
+
+If the node only needs to recover inconsistent `mem_*` tables while the persisted blockchain is intact, checkpoint recovery (when available) or a local rebuild/replay is usually faster than restoring a full database image.
 
 If you prefer to use an up-to-date blockchain image and restore the node in minutes, run this script:
 


### PR DESCRIPTION
## Description

This PR releases documentation changes accumulated in `dev` for node v0.10.2. It merges `dev` into `main` to publish the updated site at [docs.adamant.im](https://docs.adamant.im).

### Summary of changes (`origin/main`…`origin/dev`)

9 files changed, +364 / −96 lines.

**API — Accounts**
- `api-endpoints/accounts.md` — document `GET /api/accounts/top`: non-zero-balance accounts sorted by `balance` (then `address`), pagination via `limit`/`offset`, optional `isDelegate` filter, and `count` semantics

**API — Blockchain status**
- `api-endpoints/blockchain.md` — document `consensusCodeName` on network status; document `consensusSchedule.activationHeights` and `milestoneSchedule` (`offset`, `distance`, `milestones`) on `/api/node/status`

**API — Blocks**
- `api-endpoints/blocks.md` — align list parameters with node behavior (`orderBy`, filters for `numberOfTransactions`, `previousBlock`, amount fields); clarify that `offset` skips rows after ordering; remove incorrect `timestampMs: null` examples; document amount units as 1/10^8 ADM

**API — Delegates**
- `api-endpoints/delegates.md` — document lifetime `forged` (base units string) on list/get; note that search omits `forged`; clarify `getNextForgers` as a next-block schedule snapshot and `limit` range (1–101, default 10)

**API — Transactions query language**
- `api/transactions-query-language.md` — document how `and:` / `or:` prefixes compose a flat SQL `WHERE` (order matters, no grouping, `AND` before `OR`), with examples and a caution about mixing address filters with `or:`

**API — WebSocket**
- `api/websocket.md` — expand client events: address/types/`assetChatTypes` subscriptions; `balances` + `balances/change` (field-level payloads, confirmed vs unconfirmed); `blocks` + `newBlock` (compact header after successful application); delivery and reconciliation notes

**Own node — Configuration & installation**
- `own-node/configuration.md` — remove obsolete `topAccounts` flag; document `loading.memCheckpoints.enabled` and checkpoint recovery behavior
- `own-node/installation.md` — expand graceful-shutdown warning; add Mem-table checkpoint recovery section (logs, fallback to full rebuild, storage impact ~48 MB/slot)

**Repository meta**
- `.gitignore` — ignore `.ai-tasks/`, `.claude/`, `.cursor/`

### Included merge PRs

- #29 — Top Accounts API
- #31 — Mem-table checkpoint recovery
- #33 — Blocks API docs fixes
- #35 — Client WebSocket events
- #37 — Status schedules and forged delegates

## Related issue

Closes #38

## External links (optional)

- Published site: https://docs.adamant.im
- Node release context: ADAMANT node v0.10.2

## Screenshots or videos (optional)

N/A — documentation-only changes.

## Breaking changes

No breaking changes to the docs site structure. Content updates document new and corrected API/operator behavior for node v0.10.2. Notable doc corrections: Blocks list parameters/ordering, removal of incorrect `timestampMs` examples, and removal of the obsolete `topAccounts` config flag (endpoint is available without a feature flag).

## How to test

1. After merge, confirm the deployment at [docs.adamant.im](https://docs.adamant.im) completes successfully.
2. Open `/api-endpoints/accounts.html` and verify the Top Accounts section.
3. Open `/api/websocket.html` and verify balance and block event sections.
4. Open `/api-endpoints/blockchain.html` and `/api-endpoints/delegates.html` and verify status schedules / `forged` / next forgers.
5. Open `/own-node/installation.html` and `/own-node/configuration.html` and verify mem-table checkpoint recovery docs.
6. Spot-check Blocks and transactions query language pages for the corrected parameter and precedence notes.

## Notes for reviewers

This is a release PR (`dev` → `main`). Review the full diff summary above; individual feature work was already reviewed in PRs #29, #31, #33, #35, and #37.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed) — no test suite; content landed via prior PRs on `dev`
- [x] Documentation updated (if needed) — this PR is the documentation release
- [x] Changes tested in all relevant environments
